### PR TITLE
ConcertActorで使用するメッセージのフィールドを整理する

### DIFF
--- a/sample-app/src/main/scala/example/model/concert/actor/ConcertActorProtocol.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/ConcertActorProtocol.scala
@@ -11,9 +11,7 @@ object ConcertActorProtocol {
   /** ConcertActor へのリクエストメッセージ
     * シリアライズされる
     */
-  sealed trait ConcertCommandRequest extends KryoSerializable {
-    def concertId: ConcertId
-  }
+  sealed trait ConcertCommandRequest extends KryoSerializable
 
   /** ConcertActor からのレスポンスメッセージ
     * シリアライズされる
@@ -22,7 +20,7 @@ object ConcertActorProtocol {
 
   // --
 
-  case class CreateConcertRequest(concertId: ConcertId, numTickets: Int)(val replyTo: ActorRef[CreateConcertResponse])
+  case class CreateConcertRequest(numTickets: Int)(val replyTo: ActorRef[CreateConcertResponse])
       extends ConcertCommandRequest
   sealed trait CreateConcertResponse                  extends ConcertCommandResponse
   case class CreateConcertSucceeded(numTickets: Int)  extends CreateConcertResponse
@@ -30,24 +28,22 @@ object ConcertActorProtocol {
 
   // --
 
-  case class GetConcertRequest(concertId: ConcertId)(val replyTo: ActorRef[GetConcertResponse])
-      extends ConcertCommandRequest
-  sealed trait GetConcertResponse extends ConcertCommandResponse
+  case class GetConcertRequest()(val replyTo: ActorRef[GetConcertResponse]) extends ConcertCommandRequest
+  sealed trait GetConcertResponse                                           extends ConcertCommandResponse
   case class GetConcertSucceeded(id: ConcertId, tickets: Vector[ConcertTicketId], cancelled: Boolean)
       extends GetConcertResponse
   case class GetConcertFailed(error: ConcertError) extends GetConcertResponse
 
   // --
 
-  case class CancelConcertRequest(concertId: ConcertId)(val replyTo: ActorRef[CancelConcertResponse])
-      extends ConcertCommandRequest
-  sealed trait CancelConcertResponse                      extends ConcertCommandResponse
-  case class CancelConcertSucceeded(numberOfTickets: Int) extends CancelConcertResponse
-  case class CancelConcertFailed(error: ConcertError)     extends CancelConcertResponse
+  case class CancelConcertRequest()(val replyTo: ActorRef[CancelConcertResponse]) extends ConcertCommandRequest
+  sealed trait CancelConcertResponse                                              extends ConcertCommandResponse
+  case class CancelConcertSucceeded(numberOfTickets: Int)                         extends CancelConcertResponse
+  case class CancelConcertFailed(error: ConcertError)                             extends CancelConcertResponse
 
   // --
 
-  case class BuyConcertTicketsRequest(concertId: ConcertId, numberOfTickets: Int)(
+  case class BuyConcertTicketsRequest(numberOfTickets: Int)(
       val replyTo: ActorRef[BuyConcertTicketsResponse],
   )                                                                       extends ConcertCommandRequest
   sealed trait BuyConcertTicketsResponse                                  extends ConcertCommandResponse

--- a/sample-app/src/main/scala/example/model/concert/actor/ConcertActorProtocol.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/ConcertActorProtocol.scala
@@ -28,11 +28,10 @@ object ConcertActorProtocol {
 
   // --
 
-  case class GetConcertRequest(replyTo: ActorRef[GetConcertResponse]) extends ConcertCommandRequest
-  sealed trait GetConcertResponse                                     extends ConcertCommandResponse
-  case class GetConcertSucceeded(id: ConcertId, tickets: Vector[ConcertTicketId], cancelled: Boolean)
-      extends GetConcertResponse
-  case class GetConcertFailed(error: ConcertError) extends GetConcertResponse
+  case class GetConcertRequest(replyTo: ActorRef[GetConcertResponse])                  extends ConcertCommandRequest
+  sealed trait GetConcertResponse                                                      extends ConcertCommandResponse
+  case class GetConcertSucceeded(tickets: Vector[ConcertTicketId], cancelled: Boolean) extends GetConcertResponse
+  case class GetConcertFailed(error: ConcertError)                                     extends GetConcertResponse
 
   // --
 

--- a/sample-app/src/main/scala/example/model/concert/actor/ConcertActorProtocol.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/ConcertActorProtocol.scala
@@ -20,7 +20,7 @@ object ConcertActorProtocol {
 
   // --
 
-  case class CreateConcertRequest(numTickets: Int)(val replyTo: ActorRef[CreateConcertResponse])
+  case class CreateConcertRequest(numTickets: Int, replyTo: ActorRef[CreateConcertResponse])
       extends ConcertCommandRequest
   sealed trait CreateConcertResponse                  extends ConcertCommandResponse
   case class CreateConcertSucceeded(numTickets: Int)  extends CreateConcertResponse
@@ -28,24 +28,23 @@ object ConcertActorProtocol {
 
   // --
 
-  case class GetConcertRequest()(val replyTo: ActorRef[GetConcertResponse]) extends ConcertCommandRequest
-  sealed trait GetConcertResponse                                           extends ConcertCommandResponse
+  case class GetConcertRequest(replyTo: ActorRef[GetConcertResponse]) extends ConcertCommandRequest
+  sealed trait GetConcertResponse                                     extends ConcertCommandResponse
   case class GetConcertSucceeded(id: ConcertId, tickets: Vector[ConcertTicketId], cancelled: Boolean)
       extends GetConcertResponse
   case class GetConcertFailed(error: ConcertError) extends GetConcertResponse
 
   // --
 
-  case class CancelConcertRequest()(val replyTo: ActorRef[CancelConcertResponse]) extends ConcertCommandRequest
-  sealed trait CancelConcertResponse                                              extends ConcertCommandResponse
-  case class CancelConcertSucceeded(numberOfTickets: Int)                         extends CancelConcertResponse
-  case class CancelConcertFailed(error: ConcertError)                             extends CancelConcertResponse
+  case class CancelConcertRequest(replyTo: ActorRef[CancelConcertResponse]) extends ConcertCommandRequest
+  sealed trait CancelConcertResponse                                        extends ConcertCommandResponse
+  case class CancelConcertSucceeded(numberOfTickets: Int)                   extends CancelConcertResponse
+  case class CancelConcertFailed(error: ConcertError)                       extends CancelConcertResponse
 
   // --
 
-  case class BuyConcertTicketsRequest(numberOfTickets: Int)(
-      val replyTo: ActorRef[BuyConcertTicketsResponse],
-  )                                                                       extends ConcertCommandRequest
+  case class BuyConcertTicketsRequest(numberOfTickets: Int, val replyTo: ActorRef[BuyConcertTicketsResponse])
+      extends ConcertCommandRequest
   sealed trait BuyConcertTicketsResponse                                  extends ConcertCommandResponse
   case class BuyConcertTicketsSucceeded(tickets: Vector[ConcertTicketId]) extends BuyConcertTicketsResponse
   case class BuyConcertTicketsFailed(error: ConcertError)                 extends BuyConcertTicketsResponse

--- a/sample-app/src/main/scala/example/model/concert/actor/ConcertActorProtocol.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/ConcertActorProtocol.scala
@@ -43,7 +43,7 @@ object ConcertActorProtocol {
 
   // --
 
-  case class BuyConcertTicketsRequest(numberOfTickets: Int, val replyTo: ActorRef[BuyConcertTicketsResponse])
+  case class BuyConcertTicketsRequest(numberOfTickets: Int, replyTo: ActorRef[BuyConcertTicketsResponse])
       extends ConcertCommandRequest
   sealed trait BuyConcertTicketsResponse                                  extends ConcertCommandResponse
   case class BuyConcertTicketsSucceeded(tickets: Vector[ConcertTicketId]) extends BuyConcertTicketsResponse

--- a/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActor.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActor.scala
@@ -48,7 +48,7 @@ object DefaultConcertActor extends ConcertActorBehaviorFactory {
             Effect.reply(createRequest.replyTo)(CreateConcertFailed(error))
           } else {
             // 作成成功
-            val event = ConcertCreated(createRequest.concertId, createRequest.numTickets, ZonedDateTime.now)
+            val event = ConcertCreated(id, createRequest.numTickets, ZonedDateTime.now)
             Effect.persist(event).thenReply(createRequest.replyTo)(_ => CreateConcertSucceeded(event.numOfTickets))
           }
         case cancelRequest: CancelConcertRequest =>

--- a/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActor.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActor.scala
@@ -76,7 +76,7 @@ object DefaultConcertActor extends ConcertActorBehaviorFactory {
     override def applyCommand(command: ConcertCommandRequest): ReplyEffect = {
       command match {
         case getRequest: GetConcertRequest =>
-          Effect.reply(getRequest.replyTo)(GetConcertSucceeded(id, tickets, cancelled = false))
+          Effect.reply(getRequest.replyTo)(GetConcertSucceeded(tickets, cancelled = false))
         case createRequest: CreateConcertRequest =>
           // 既に作成済みなのでエラー
           Effect.reply(createRequest.replyTo)(CreateConcertFailed(DuplicatedConcertError(id)))
@@ -123,7 +123,7 @@ object DefaultConcertActor extends ConcertActorBehaviorFactory {
       command match {
         case getRequest: GetConcertRequest =>
           // 取得処理は成功する
-          Effect.reply(getRequest.replyTo)(GetConcertSucceeded(id, tickets, cancelled = true))
+          Effect.reply(getRequest.replyTo)(GetConcertSucceeded(tickets, cancelled = true))
         case createRequest: CreateConcertRequest =>
           // すでにコンサートが存在するのでエラー
           Effect.reply(createRequest.replyTo)(CreateConcertFailed(DuplicatedConcertError(id)))

--- a/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActorWithEventPersistence.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActorWithEventPersistence.scala
@@ -44,7 +44,7 @@ object DefaultConcertActorWithEventPersistence extends ConcertActorBehaviorFacto
             Effect.reply(createRequest.replyTo)(CreateConcertFailed(error))
           } else {
             // 作成成功
-            val event = ConcertCreated(createRequest.concertId, createRequest.numTickets, ZonedDateTime.now)
+            val event = ConcertCreated(id, createRequest.numTickets, ZonedDateTime.now)
             Effect.persist(event).thenReply(createRequest.replyTo)(_ => CreateConcertSucceeded(event.numOfTickets))
           }
         case cancelRequest: CancelConcertRequest =>

--- a/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActorWithEventPersistence.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActorWithEventPersistence.scala
@@ -72,7 +72,7 @@ object DefaultConcertActorWithEventPersistence extends ConcertActorBehaviorFacto
     override def applyCommand(command: ConcertCommandRequest): ReplyEffect = {
       command match {
         case getRequest: GetConcertRequest =>
-          Effect.reply(getRequest.replyTo)(GetConcertSucceeded(id, tickets, cancelled = false))
+          Effect.reply(getRequest.replyTo)(GetConcertSucceeded(tickets, cancelled = false))
         case createRequest: CreateConcertRequest =>
           // 既に作成済みなのでエラー
           Effect.reply(createRequest.replyTo)(CreateConcertFailed(DuplicatedConcertError(id)))
@@ -119,7 +119,7 @@ object DefaultConcertActorWithEventPersistence extends ConcertActorBehaviorFacto
       command match {
         case getRequest: GetConcertRequest =>
           // 取得処理は成功する
-          Effect.reply(getRequest.replyTo)(GetConcertSucceeded(id, tickets, cancelled = true))
+          Effect.reply(getRequest.replyTo)(GetConcertSucceeded(tickets, cancelled = true))
         case createRequest: CreateConcertRequest =>
           // すでにコンサートが存在するのでエラー
           Effect.reply(createRequest.replyTo)(CreateConcertFailed(DuplicatedConcertError(id)))

--- a/sample-app/src/main/scala/example/model/concert/service/DefaultBoxOfficeService.scala
+++ b/sample-app/src/main/scala/example/model/concert/service/DefaultBoxOfficeService.scala
@@ -22,7 +22,7 @@ final class DefaultBoxOfficeService(
 
   override def createConcert(id: ConcertId, numberOfTickets: Int): Future[CreateConcertResponse] = {
     val entityRef = sharding.entityRefFor(id)
-    entityRef ? CreateConcertRequest(id, numberOfTickets)
+    entityRef ? CreateConcertRequest(numberOfTickets)
   }
 
   override def getConcert(id: ConcertId): Future[GetConcertResponse] = {
@@ -31,17 +31,17 @@ final class DefaultBoxOfficeService(
     // リクエストが複数回　Ask先に到達して処理される可能性があるので、冪等な処理にのみ使える。
     // TODO Use AtLeastOnceDelivery
     val entityRef = sharding.entityRefFor(id)
-    entityRef ? GetConcertRequest(id)
+    entityRef ? GetConcertRequest()
   }
 
   override def cancelConcert(id: ConcertId): Future[CancelConcertResponse] = {
     val entityRef = sharding.entityRefFor(id)
-    entityRef ? CancelConcertRequest(id)
+    entityRef ? CancelConcertRequest()
   }
 
   override def buyConcertTickets(id: ConcertId, numberOfTickets: Int): Future[BuyConcertTicketsResponse] = {
     val entityRef = sharding.entityRefFor(id)
-    entityRef ? BuyConcertTicketsRequest(id, numberOfTickets)
+    entityRef ? BuyConcertTicketsRequest(numberOfTickets)
   }
 
 }

--- a/sample-app/src/main/scala/example/model/concert/service/DefaultBoxOfficeService.scala
+++ b/sample-app/src/main/scala/example/model/concert/service/DefaultBoxOfficeService.scala
@@ -22,7 +22,7 @@ final class DefaultBoxOfficeService(
 
   override def createConcert(id: ConcertId, numberOfTickets: Int): Future[CreateConcertResponse] = {
     val entityRef = sharding.entityRefFor(id)
-    entityRef ? CreateConcertRequest(numberOfTickets)
+    entityRef.ask(replyTo => CreateConcertRequest(numberOfTickets, replyTo))
   }
 
   override def getConcert(id: ConcertId): Future[GetConcertResponse] = {
@@ -31,17 +31,17 @@ final class DefaultBoxOfficeService(
     // リクエストが複数回　Ask先に到達して処理される可能性があるので、冪等な処理にのみ使える。
     // TODO Use AtLeastOnceDelivery
     val entityRef = sharding.entityRefFor(id)
-    entityRef ? GetConcertRequest()
+    entityRef.ask(replyTo => GetConcertRequest(replyTo))
   }
 
   override def cancelConcert(id: ConcertId): Future[CancelConcertResponse] = {
     val entityRef = sharding.entityRefFor(id)
-    entityRef ? CancelConcertRequest()
+    entityRef.ask(replyTo => CancelConcertRequest(replyTo))
   }
 
   override def buyConcertTickets(id: ConcertId, numberOfTickets: Int): Future[BuyConcertTicketsResponse] = {
     val entityRef = sharding.entityRefFor(id)
-    entityRef ? BuyConcertTicketsRequest(numberOfTickets)
+    entityRef.ask(replyTo => BuyConcertTicketsRequest(numberOfTickets, replyTo))
   }
 
 }

--- a/sample-app/src/test/scala/example/model/concert/actor/ConcertActorBehaviors.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/ConcertActorBehaviors.scala
@@ -31,7 +31,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
     def create(id: ConcertId, numOfTickets: Int): ActorRef[ConcertCommandRequest] = {
       val actor = underlyingFactory.create(id)
       val probe = testKit.createTestProbe[CreateConcertResponse]()
-      actor ! CreateConcertRequest(numOfTickets)(probe.ref)
+      actor ! CreateConcertRequest(numOfTickets, probe.ref)
       probe.expectMessageType[CreateConcertSucceeded]
       actor
     }
@@ -42,7 +42,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
     def create(id: ConcertId, numOfTickets: Int): ActorRef[ConcertCommandRequest] = {
       val actor = underlyingFactory.create(id, numOfTickets)
       val probe = testKit.createTestProbe[CancelConcertResponse]()
-      actor ! CancelConcertRequest()(probe.ref)
+      actor ! CancelConcertRequest(probe.ref)
       probe.expectMessageType[CancelConcertSucceeded]
       actor
     }
@@ -56,7 +56,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val numOfTickets = 3
 
       val probe = testKit.createTestProbe[CreateConcertResponse]()
-      actor ! CreateConcertRequest(numOfTickets)(probe.ref)
+      actor ! CreateConcertRequest(numOfTickets, probe.ref)
       val resp = probe.expectMessageType[CreateConcertSucceeded]
       resp.numTickets shouldBe numOfTickets
     }
@@ -66,7 +66,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id)
 
       val probe = testKit.createTestProbe[GetConcertResponse]()
-      actor ! GetConcertRequest()(probe.ref)
+      actor ! GetConcertRequest(probe.ref)
       val resp = probe.expectMessageType[GetConcertFailed]
       resp.error shouldBe a[ConcertNotFoundError]
     }
@@ -76,7 +76,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id)
 
       val probe = testKit.createTestProbe[CancelConcertResponse]()
-      actor ! CancelConcertRequest()(probe.ref)
+      actor ! CancelConcertRequest(probe.ref)
       val resp = probe.expectMessageType[CancelConcertFailed]
       resp.error shouldBe a[ConcertNotFoundError]
     }
@@ -90,7 +90,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id, numOfTickets = 3)
 
       val probe = testKit.createTestProbe[CreateConcertResponse]()
-      actor ! CreateConcertRequest(2)(probe.ref)
+      actor ! CreateConcertRequest(2, probe.ref)
       val resp = probe.expectMessageType[CreateConcertFailed]
       resp.error shouldBe a[DuplicatedConcertError]
     }
@@ -100,7 +100,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id, numOfTickets = 3)
 
       val probe = testKit.createTestProbe[GetConcertResponse]()
-      actor ! GetConcertRequest()(probe.ref)
+      actor ! GetConcertRequest(probe.ref)
       val resp = probe.expectMessageType[GetConcertSucceeded]
       resp.id shouldBe id
       resp.tickets.size shouldBe 3
@@ -111,7 +111,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id, numOfTickets = 3)
 
       val probe = testKit.createTestProbe[CancelConcertResponse]()
-      actor ! CancelConcertRequest()(probe.ref)
+      actor ! CancelConcertRequest(probe.ref)
       val resp = probe.expectMessageType[CancelConcertSucceeded]
       resp.numberOfTickets shouldBe 3
     }
@@ -121,7 +121,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id, numOfTickets = 2)
 
       val probe = testKit.createTestProbe[BuyConcertTicketsResponse]()
-      actor ! BuyConcertTicketsRequest(2)(probe.ref)
+      actor ! BuyConcertTicketsRequest(2, probe.ref)
       val resp = probe.expectMessageType[BuyConcertTicketsSucceeded]
       resp.tickets.size shouldBe 2
     }
@@ -131,7 +131,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id, numOfTickets = 2)
 
       val probe = testKit.createTestProbe[BuyConcertTicketsResponse]()
-      actor ! BuyConcertTicketsRequest(0)(probe.ref)
+      actor ! BuyConcertTicketsRequest(0, probe.ref)
       val resp = probe.expectMessageType[BuyConcertTicketsFailed]
       resp.error shouldBe a[InvalidConcertOperationError]
     }
@@ -141,7 +141,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id, numOfTickets = 2)
 
       val probe = testKit.createTestProbe[BuyConcertTicketsResponse]()
-      actor ! BuyConcertTicketsRequest(3)(probe.ref)
+      actor ! BuyConcertTicketsRequest(3, probe.ref)
       val resp = probe.expectMessageType[BuyConcertTicketsFailed]
       resp.error shouldBe a[InvalidConcertOperationError]
     }
@@ -155,7 +155,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id, numOfTickets = 2)
 
       val probe = testKit.createTestProbe[GetConcertResponse]()
-      actor ! GetConcertRequest()(probe.ref)
+      actor ! GetConcertRequest(probe.ref)
       val resp = probe.expectMessageType[GetConcertSucceeded]
       resp.tickets.size shouldBe 2
       resp.cancelled shouldBe true
@@ -166,7 +166,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id, numOfTickets = 1)
 
       val probe = testKit.createTestProbe[CancelConcertResponse]()
-      actor ! CancelConcertRequest()(probe.ref)
+      actor ! CancelConcertRequest(probe.ref)
       val resp = probe.expectMessageType[CancelConcertFailed]
       resp.error shouldBe a[InvalidConcertOperationError]
     }

--- a/sample-app/src/test/scala/example/model/concert/actor/ConcertActorBehaviors.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/ConcertActorBehaviors.scala
@@ -102,7 +102,6 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val probe = testKit.createTestProbe[GetConcertResponse]()
       actor ! GetConcertRequest(probe.ref)
       val resp = probe.expectMessageType[GetConcertSucceeded]
-      resp.id shouldBe id
       resp.tickets.size shouldBe 3
     }
 

--- a/sample-app/src/test/scala/example/model/concert/actor/ConcertActorBehaviors.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/ConcertActorBehaviors.scala
@@ -31,7 +31,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
     def create(id: ConcertId, numOfTickets: Int): ActorRef[ConcertCommandRequest] = {
       val actor = underlyingFactory.create(id)
       val probe = testKit.createTestProbe[CreateConcertResponse]()
-      actor ! CreateConcertRequest(id, numOfTickets)(probe.ref)
+      actor ! CreateConcertRequest(numOfTickets)(probe.ref)
       probe.expectMessageType[CreateConcertSucceeded]
       actor
     }
@@ -42,7 +42,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
     def create(id: ConcertId, numOfTickets: Int): ActorRef[ConcertCommandRequest] = {
       val actor = underlyingFactory.create(id, numOfTickets)
       val probe = testKit.createTestProbe[CancelConcertResponse]()
-      actor ! CancelConcertRequest(id)(probe.ref)
+      actor ! CancelConcertRequest()(probe.ref)
       probe.expectMessageType[CancelConcertSucceeded]
       actor
     }
@@ -56,7 +56,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val numOfTickets = 3
 
       val probe = testKit.createTestProbe[CreateConcertResponse]()
-      actor ! CreateConcertRequest(id, numOfTickets)(probe.ref)
+      actor ! CreateConcertRequest(numOfTickets)(probe.ref)
       val resp = probe.expectMessageType[CreateConcertSucceeded]
       resp.numTickets shouldBe numOfTickets
     }
@@ -66,7 +66,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id)
 
       val probe = testKit.createTestProbe[GetConcertResponse]()
-      actor ! GetConcertRequest(id)(probe.ref)
+      actor ! GetConcertRequest()(probe.ref)
       val resp = probe.expectMessageType[GetConcertFailed]
       resp.error shouldBe a[ConcertNotFoundError]
     }
@@ -76,7 +76,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id)
 
       val probe = testKit.createTestProbe[CancelConcertResponse]()
-      actor ! CancelConcertRequest(id)(probe.ref)
+      actor ! CancelConcertRequest()(probe.ref)
       val resp = probe.expectMessageType[CancelConcertFailed]
       resp.error shouldBe a[ConcertNotFoundError]
     }
@@ -90,7 +90,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id, numOfTickets = 3)
 
       val probe = testKit.createTestProbe[CreateConcertResponse]()
-      actor ! CreateConcertRequest(id, 2)(probe.ref)
+      actor ! CreateConcertRequest(2)(probe.ref)
       val resp = probe.expectMessageType[CreateConcertFailed]
       resp.error shouldBe a[DuplicatedConcertError]
     }
@@ -100,7 +100,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id, numOfTickets = 3)
 
       val probe = testKit.createTestProbe[GetConcertResponse]()
-      actor ! GetConcertRequest(id)(probe.ref)
+      actor ! GetConcertRequest()(probe.ref)
       val resp = probe.expectMessageType[GetConcertSucceeded]
       resp.id shouldBe id
       resp.tickets.size shouldBe 3
@@ -111,7 +111,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id, numOfTickets = 3)
 
       val probe = testKit.createTestProbe[CancelConcertResponse]()
-      actor ! CancelConcertRequest(id)(probe.ref)
+      actor ! CancelConcertRequest()(probe.ref)
       val resp = probe.expectMessageType[CancelConcertSucceeded]
       resp.numberOfTickets shouldBe 3
     }
@@ -121,7 +121,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id, numOfTickets = 2)
 
       val probe = testKit.createTestProbe[BuyConcertTicketsResponse]()
-      actor ! BuyConcertTicketsRequest(id, 2)(probe.ref)
+      actor ! BuyConcertTicketsRequest(2)(probe.ref)
       val resp = probe.expectMessageType[BuyConcertTicketsSucceeded]
       resp.tickets.size shouldBe 2
     }
@@ -131,7 +131,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id, numOfTickets = 2)
 
       val probe = testKit.createTestProbe[BuyConcertTicketsResponse]()
-      actor ! BuyConcertTicketsRequest(id, 0)(probe.ref)
+      actor ! BuyConcertTicketsRequest(0)(probe.ref)
       val resp = probe.expectMessageType[BuyConcertTicketsFailed]
       resp.error shouldBe a[InvalidConcertOperationError]
     }
@@ -141,7 +141,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id, numOfTickets = 2)
 
       val probe = testKit.createTestProbe[BuyConcertTicketsResponse]()
-      actor ! BuyConcertTicketsRequest(id, 3)(probe.ref)
+      actor ! BuyConcertTicketsRequest(3)(probe.ref)
       val resp = probe.expectMessageType[BuyConcertTicketsFailed]
       resp.error shouldBe a[InvalidConcertOperationError]
     }
@@ -155,7 +155,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id, numOfTickets = 2)
 
       val probe = testKit.createTestProbe[GetConcertResponse]()
-      actor ! GetConcertRequest(id)(probe.ref)
+      actor ! GetConcertRequest()(probe.ref)
       val resp = probe.expectMessageType[GetConcertSucceeded]
       resp.tickets.size shouldBe 2
       resp.cancelled shouldBe true
@@ -166,7 +166,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor = newConcertActor.create(id, numOfTickets = 1)
 
       val probe = testKit.createTestProbe[CancelConcertResponse]()
-      actor ! CancelConcertRequest(id)(probe.ref)
+      actor ! CancelConcertRequest()(probe.ref)
       val resp = probe.expectMessageType[CancelConcertFailed]
       resp.error shouldBe a[InvalidConcertOperationError]
     }

--- a/sample-app/src/test/scala/example/model/concert/actor/ConcertActorClusterShardingBehaviors.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/ConcertActorClusterShardingBehaviors.scala
@@ -18,16 +18,16 @@ trait ConcertActorClusterShardingBehaviors extends ConcertIdGeneratorSupport wit
       val probe     = testKit.createTestProbe[ConcertCommandResponse]()
       val entityRef = sharding.entityRefFor(id)
 
-      entityRef ! CreateConcertRequest(id, 2)(probe.ref)
+      entityRef ! CreateConcertRequest(2)(probe.ref)
       probe.expectMessageType[CreateConcertSucceeded]
 
-      entityRef ! GetConcertRequest(id)(probe.ref)
+      entityRef ! GetConcertRequest()(probe.ref)
       probe.expectMessageType[GetConcertSucceeded]
 
-      entityRef ! BuyConcertTicketsRequest(id, 1)(probe.ref)
+      entityRef ! BuyConcertTicketsRequest(1)(probe.ref)
       probe.expectMessageType[BuyConcertTicketsSucceeded]
 
-      entityRef ! CancelConcertRequest(id)(probe.ref)
+      entityRef ! CancelConcertRequest()(probe.ref)
       probe.expectMessageType[CancelConcertSucceeded]
     }
 

--- a/sample-app/src/test/scala/example/model/concert/actor/ConcertActorClusterShardingBehaviors.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/ConcertActorClusterShardingBehaviors.scala
@@ -18,16 +18,16 @@ trait ConcertActorClusterShardingBehaviors extends ConcertIdGeneratorSupport wit
       val probe     = testKit.createTestProbe[ConcertCommandResponse]()
       val entityRef = sharding.entityRefFor(id)
 
-      entityRef ! CreateConcertRequest(2)(probe.ref)
+      entityRef ! CreateConcertRequest(2, probe.ref)
       probe.expectMessageType[CreateConcertSucceeded]
 
-      entityRef ! GetConcertRequest()(probe.ref)
+      entityRef ! GetConcertRequest(probe.ref)
       probe.expectMessageType[GetConcertSucceeded]
 
-      entityRef ! BuyConcertTicketsRequest(1)(probe.ref)
+      entityRef ! BuyConcertTicketsRequest(1, probe.ref)
       probe.expectMessageType[BuyConcertTicketsSucceeded]
 
-      entityRef ! CancelConcertRequest()(probe.ref)
+      entityRef ! CancelConcertRequest(probe.ref)
       probe.expectMessageType[CancelConcertSucceeded]
     }
 

--- a/sample-app/src/test/scala/example/model/concert/service/BoxOfficeServiceBehaviors.scala
+++ b/sample-app/src/test/scala/example/model/concert/service/BoxOfficeServiceBehaviors.scala
@@ -32,7 +32,7 @@ trait BoxOfficeServiceBehaviors { this: BoxOfficeServiceSpecBase =>
 
       val getResponseFuture = service.getConcert(id)
       getResponseFuture.futureValue shouldBe
-      GetConcertSucceeded(id, (1 to 10).map(ConcertTicketId).toVector, cancelled = false)
+      GetConcertSucceeded((1 to 10).map(ConcertTicketId).toVector, cancelled = false)
     }
 
     "buy concert tickets" in {


### PR DESCRIPTION
ConcertActor で使用するメッセージにフィールドを整理します。

- 🔰 Curry 化したコンストラクタの使用を止めます 
  恐らく初学者には難しいトピックです。  
  Curry 化するとメッセージのequalsに使用されないフィールドが発生します。
  ほとんどの場合には問題ないでしょうが、問題を生む可能性があるので無くしたいと考えています。
  ```sbt
  scala> case class Message(id: Int)(subId: Int)
  class Message
  
  scala> Message(1)(2) == Message(1)(3)
  val res0: Boolean = true
  ```

- 🎉 ConcertId をフィールドから削除します 
  Classic では ClusterSharding でメッセージに ConcertId を含める必要がありました。  
  Typed では ShardingEnvelope が導入されたことにより、メッセージに ConcertId を含める必要がなくなりました。

## 別PRにて追加で対応したいこと

- Typed の流儀にならい、メッセージの定義場所や名前を整理したい
-  `final case class` にしたい