### PR TITLE
サンプルアプリ全体で Typed ActorSystem をデフォルトとして使用する

### DIFF
--- a/sample-app/src/main/scala/example/Main.scala
+++ b/sample-app/src/main/scala/example/Main.scala
@@ -1,7 +1,9 @@
 package example
 
 import akka.Done
-import akka.actor.{ ActorSystem, CoordinatedShutdown }
+import akka.actor.CoordinatedShutdown
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ ActorSystem, Behavior }
 import akka.cluster.Cluster
 import example.application.http._
 import example.application.rmu._
@@ -11,9 +13,12 @@ import scala.concurrent._
 import scala.util.Failure
 
 object Main extends App {
+  object Guardian {
+    def apply(): Behavior[Nothing] = Behaviors.empty
+  }
   val logger          = LoggerFactory.getLogger(this.getClass)
-  implicit val system = ActorSystem("concerts")
-  import system.dispatcher
+  implicit val system = ActorSystem[Nothing](Guardian(), "concerts")
+  import system.executionContext
 
   // DIデザインを作成する。
   val design = MainDiDesign.design(system)

--- a/sample-app/src/main/scala/example/MainDiDesign.scala
+++ b/sample-app/src/main/scala/example/MainDiDesign.scala
@@ -15,7 +15,7 @@ object MainDiDesign {
     Design.newDesign.withProductionMode
       .bind[ActorSystem[Nothing]].toInstance(system)
       .bind[ExecutionContext].toSingletonProvider[ActorSystem[Nothing]] { system =>
-        // デフォルトでは system.dispatcher を使うようにする。
+        // デフォルトでは system.executionContext を使うようにする。
         system.executionContext
       }
       .add(ModelDiDesign.design)

--- a/sample-app/src/main/scala/example/MainDiDesign.scala
+++ b/sample-app/src/main/scala/example/MainDiDesign.scala
@@ -1,6 +1,8 @@
 package example
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.adapter.ClassicActorSystemOps
+import akka.{ actor => classic }
 import example.readmodel.DefaultReadModelDiDesign
 import example.application.http.MainHttpApiServerDiDesign
 import example.application.rmu.DefaultReadModelUpdaterDiDesign
@@ -11,12 +13,13 @@ import wvlet.airframe.Design
 import scala.concurrent.ExecutionContext
 
 object MainDiDesign {
-  def design(system: ActorSystem): Design = {
+  def design(system: classic.ActorSystem): Design = {
     Design.newDesign.withProductionMode
-      .bind[ActorSystem].toInstance(system)
-      .bind[ExecutionContext].toSingletonProvider[ActorSystem] { system =>
+      .bind[classic.ActorSystem].toInstance(system)
+      .bind[ActorSystem[Nothing]].toInstance(system.toTyped)
+      .bind[ExecutionContext].toSingletonProvider[ActorSystem[Nothing]] { system =>
         // デフォルトでは system.dispatcher を使うようにする。
-        system.dispatcher
+        system.executionContext
       }
       .add(ModelDiDesign.design)
       .add(DefaultUseCaseDiDesign.design)

--- a/sample-app/src/main/scala/example/MainDiDesign.scala
+++ b/sample-app/src/main/scala/example/MainDiDesign.scala
@@ -1,22 +1,19 @@
 package example
 
 import akka.actor.typed.ActorSystem
-import akka.actor.typed.scaladsl.adapter.ClassicActorSystemOps
-import akka.{ actor => classic }
-import example.readmodel.DefaultReadModelDiDesign
 import example.application.http.MainHttpApiServerDiDesign
 import example.application.rmu.DefaultReadModelUpdaterDiDesign
 import example.model.ModelDiDesign
+import example.readmodel.DefaultReadModelDiDesign
 import example.usecase.DefaultUseCaseDiDesign
 import wvlet.airframe.Design
 
 import scala.concurrent.ExecutionContext
 
 object MainDiDesign {
-  def design(system: classic.ActorSystem): Design = {
+  def design(system: ActorSystem[Nothing]): Design = {
     Design.newDesign.withProductionMode
-      .bind[classic.ActorSystem].toInstance(system)
-      .bind[ActorSystem[Nothing]].toInstance(system.toTyped)
+      .bind[ActorSystem[Nothing]].toInstance(system)
       .bind[ExecutionContext].toSingletonProvider[ActorSystem[Nothing]] { system =>
         // デフォルトでは system.dispatcher を使うようにする。
         system.executionContext

--- a/sample-app/src/main/scala/example/application/http/MainHttpApiServer.scala
+++ b/sample-app/src/main/scala/example/application/http/MainHttpApiServer.scala
@@ -1,7 +1,9 @@
 package example.application.http
 
 import akka.Done
-import akka.actor.{ ActorSystem, CoordinatedShutdown }
+import akka.{ actor => classic }
+import akka.actor.CoordinatedShutdown
+import akka.actor.typed.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
 import org.slf4j.LoggerFactory
@@ -11,10 +13,10 @@ import scala.concurrent._
 final class MainHttpApiServer(
     config: MainHttpApiServerConfig,
     resource: MainHttpApiServerResource,
-)(implicit
-    system: ActorSystem,
+    system: ActorSystem[Nothing],
 ) {
-  import system.dispatcher
+  import system.executionContext
+  private implicit val classicSystem: classic.ActorSystem = system.classicSystem
 
   private val log = LoggerFactory.getLogger(this.getClass)
 

--- a/sample-app/src/main/scala/example/application/http/MainHttpApiServerConfig.scala
+++ b/sample-app/src/main/scala/example/application/http/MainHttpApiServerConfig.scala
@@ -1,11 +1,11 @@
 package example.application.http
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
 
 import scala.concurrent.duration._
 
 object MainHttpApiServerConfig {
-  def apply(system: ActorSystem): MainHttpApiServerConfig = {
+  def apply(system: ActorSystem[Nothing]): MainHttpApiServerConfig = {
     val config = system.settings.config.getConfig("example.http-api-server")
     new MainHttpApiServerConfig(
       config.getString("host"),

--- a/sample-app/src/main/scala/example/application/http/MainHttpApiServerDiDesign.scala
+++ b/sample-app/src/main/scala/example/application/http/MainHttpApiServerDiDesign.scala
@@ -1,6 +1,6 @@
 package example.application.http
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
 import example.application.http.controller._
 import wvlet.airframe.Design
 
@@ -8,11 +8,11 @@ object MainHttpApiServerDiDesign {
   // format: off
   lazy val design: Design =
     Design.newDesign
-      .bind[MainHttpApiServerConfig].toSingletonProvider[ActorSystem] { system =>
+      .bind[MainHttpApiServerConfig].toSingletonProvider[ActorSystem[Nothing]] { system =>
         MainHttpApiServerConfig(system)
       }
-      .bind[ResourceExecutionContext].toSingletonProvider[ActorSystem] { system =>
-        system.dispatcher // akka.http のルーティングで使用するdispatcherを準備する。
+      .bind[ResourceExecutionContext].toSingletonProvider[ActorSystem[Nothing]] { system =>
+        system.executionContext // TODO akka.http のルーティングで使用するdispatcherを準備する。
       }
       .bind[MainHttpApiServerResource].to[DefaultBoxOfficeResource]
       // MyBoxOfficeResource 実装時にコメントアウトを外す (この行はそのまま)

--- a/sample-app/src/main/scala/example/application/http/MainHttpApiServerDiDesign.scala
+++ b/sample-app/src/main/scala/example/application/http/MainHttpApiServerDiDesign.scala
@@ -12,7 +12,7 @@ object MainHttpApiServerDiDesign {
         MainHttpApiServerConfig(system)
       }
       .bind[ResourceExecutionContext].toSingletonProvider[ActorSystem[Nothing]] { system =>
-        system.executionContext // TODO akka.http のルーティングで使用するdispatcherを準備する。
+        system.executionContext // TODO akka.http のルーティングで使用する ExecutionContext を準備する。
       }
       .bind[MainHttpApiServerResource].to[DefaultBoxOfficeResource]
       // MyBoxOfficeResource 実装時にコメントアウトを外す (この行はそのまま)

--- a/sample-app/src/main/scala/example/application/rmu/CassandraConcertEventSourceFactory.scala
+++ b/sample-app/src/main/scala/example/application/rmu/CassandraConcertEventSourceFactory.scala
@@ -1,7 +1,7 @@
 package example.application.rmu
 
 import akka.NotUsed
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
 import akka.persistence.query.{ Offset, PersistenceQuery }
 import akka.stream.scaladsl.Source
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory
 /** Cassandra からイベントを読み込むストリームを生成する
   * @param system
   */
-final class CassandraConcertEventSourceFactory(system: ActorSystem) extends ConcertEventSourceFactory {
+final class CassandraConcertEventSourceFactory(system: ActorSystem[Nothing]) extends ConcertEventSourceFactory {
   private val logger  = LoggerFactory.getLogger(this.getClass)
   private val queries = PersistenceQuery(system).readJournalFor[CassandraReadJournal](CassandraReadJournal.Identifier)
 

--- a/sample-app/src/main/scala/example/application/rmu/ConcertReadModelUpdateServer.scala
+++ b/sample-app/src/main/scala/example/application/rmu/ConcertReadModelUpdateServer.scala
@@ -1,10 +1,8 @@
 package example.application.rmu
 
-import akka.actor.typed.SupervisorStrategy
 import akka.actor.typed.scaladsl.Behaviors
-import akka.actor.typed.scaladsl.adapter._
+import akka.actor.typed.{ ActorSystem, SupervisorStrategy }
 import akka.cluster.typed.{ ClusterSingleton, SingletonActor }
-import akka.{ actor => classic }
 import example.readmodel.ConcertRepository
 
 import scala.concurrent.duration._
@@ -13,9 +11,9 @@ final class ConcertReadModelUpdateServer(
     factory: ConcertEventSourceFactory,
     repository: ConcertRepository,
 )(implicit
-    system: classic.ActorSystem,
+    system: ActorSystem[Nothing],
 ) {
-  private val singletonManager = ClusterSingleton(system.toTyped)
+  private val singletonManager = ClusterSingleton(system)
 
   def start(): Unit = {
     val rmuActor = SingletonActor(

--- a/sample-app/src/main/scala/example/model/concert/service/BoxOfficeServiceConfig.scala
+++ b/sample-app/src/main/scala/example/model/concert/service/BoxOfficeServiceConfig.scala
@@ -1,12 +1,12 @@
 package example.model.concert.service
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
 import akka.util.Timeout
 
 import scala.concurrent.duration._
 
 object BoxOfficeServiceConfig {
-  def apply(system: ActorSystem): BoxOfficeServiceConfig = {
+  def apply(system: ActorSystem[Nothing]): BoxOfficeServiceConfig = {
     val config = system.settings.config.getConfig("example.box-office-service")
     new BoxOfficeServiceConfig(
       config.getDuration("response-timeout", MICROSECONDS).micros,

--- a/sample-app/src/main/scala/example/model/concert/service/DefaultBoxOfficeService.scala
+++ b/sample-app/src/main/scala/example/model/concert/service/DefaultBoxOfficeService.scala
@@ -1,15 +1,14 @@
 package example.model.concert.service
 
-import akka.actor.typed.scaladsl.adapter._
+import akka.actor.typed.ActorSystem
 import akka.util.Timeout
-import akka.{ actor => classic }
 import example.model.concert.ConcertId
 import example.model.concert.actor.ConcertActorClusterShardingFactory
 
 import scala.concurrent.Future
 
 final class DefaultBoxOfficeService(
-    system: classic.ActorSystem,
+    system: ActorSystem[Nothing],
     factory: ConcertActorClusterShardingFactory,
 ) extends BoxOfficeService {
   import example.model.concert.actor.ConcertActorProtocol._
@@ -18,7 +17,7 @@ final class DefaultBoxOfficeService(
   private val config                            = BoxOfficeServiceConfig(system)
   private implicit val responseTimeout: Timeout = config.responseTimeout
 
-  private val sharding = factory.create(system.toTyped)
+  private val sharding = factory.create(system)
 
   override def createConcert(id: ConcertId, numberOfTickets: Int): Future[CreateConcertResponse] = {
     val entityRef = sharding.entityRefFor(id)

--- a/sample-app/src/main/scala/example/model/concert/service/MyBoxOfficeService.scala
+++ b/sample-app/src/main/scala/example/model/concert/service/MyBoxOfficeService.scala
@@ -2,7 +2,6 @@ package example.model.concert.service
 
 import akka.actor.typed.scaladsl.adapter._
 import akka.actor.typed.{ ActorRef, ActorSystem }
-import akka.{ actor => classic }
 import akka.util.Timeout
 import example.model.concert.ConcertId
 import example.model.concert.actor.ConcertActorClusterShardingFactory
@@ -13,7 +12,7 @@ import scala.concurrent.Future
   * Actor とのリクエスト/レスポンスを扱う。
   */
 final class MyBoxOfficeService(
-    system: classic.ActorSystem,
+    system: ActorSystem[Nothing],
     factory: ConcertActorClusterShardingFactory,
 ) extends BoxOfficeService {
   import example.model.concert.actor.ConcertActorProtocol._
@@ -22,7 +21,7 @@ final class MyBoxOfficeService(
   private val config                            = BoxOfficeServiceConfig(system)
   private implicit val responseTimeout: Timeout = config.responseTimeout
 
-  private val sharding = factory.create(system.toTyped)
+  private val sharding = factory.create(system)
 
   override def createConcert(id: ConcertId, numberOfTickets: Int): Future[CreateConcertResponse] = {
     ???

--- a/sample-app/src/main/scala/example/readmodel/DefaultReadModelDiDesign.scala
+++ b/sample-app/src/main/scala/example/readmodel/DefaultReadModelDiDesign.scala
@@ -15,7 +15,7 @@ object DefaultReadModelDiDesign {
         DefaultConcertDatabaseServiceConfig(system)
       }
       .bind[RepositoryExecutionContext].toSingletonProvider[ActorSystem[Nothing]] { system =>
-        system.executionContext // TODO RDB用のdispatcherを提供する。
+        system.executionContext // TODO RDB用の ExecutionContxt を提供する。
       }
       .bind[ConcertRepository].to[DefaultConcertRepository]
       // MyBoxOfficeService実装時にコメントアウトを外す (この行はそのまま)

--- a/sample-app/src/main/scala/example/readmodel/DefaultReadModelDiDesign.scala
+++ b/sample-app/src/main/scala/example/readmodel/DefaultReadModelDiDesign.scala
@@ -1,6 +1,6 @@
 package example.readmodel
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
 import example.readmodel.rdb._
 import wvlet.airframe._
 
@@ -11,11 +11,11 @@ object DefaultReadModelDiDesign {
   lazy val design: Design =
     newDesign
       .bind[ConcertDatabaseService].to[DefaultConcertDatabaseService]
-      .bind[DefaultConcertDatabaseServiceConfig].toSingletonProvider[ActorSystem] { system =>
+      .bind[DefaultConcertDatabaseServiceConfig].toSingletonProvider[ActorSystem[Nothing]] { system =>
         DefaultConcertDatabaseServiceConfig(system)
       }
-      .bind[RepositoryExecutionContext].toSingletonProvider[ActorSystem] { system =>
-        system.dispatcher // TODO RDB用のdispatcherを提供する。
+      .bind[RepositoryExecutionContext].toSingletonProvider[ActorSystem[Nothing]] { system =>
+        system.executionContext // TODO RDB用のdispatcherを提供する。
       }
       .bind[ConcertRepository].to[DefaultConcertRepository]
       // MyBoxOfficeService実装時にコメントアウトを外す (この行はそのまま)

--- a/sample-app/src/main/scala/example/readmodel/rdb/DefaultConcertDatabaseServiceConfig.scala
+++ b/sample-app/src/main/scala/example/readmodel/rdb/DefaultConcertDatabaseServiceConfig.scala
@@ -1,6 +1,6 @@
 package example.readmodel.rdb
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 
@@ -12,7 +12,7 @@ final class DefaultConcertDatabaseServiceConfig(
 )
 
 object DefaultConcertDatabaseServiceConfig {
-  def apply(system: ActorSystem): DefaultConcertDatabaseServiceConfig = {
+  def apply(system: ActorSystem[Nothing]): DefaultConcertDatabaseServiceConfig = {
     val config = DatabaseConfig.forConfig[JdbcProfile]("example.database.concert", system.settings.config)
     new DefaultConcertDatabaseServiceConfig(config)
   }

--- a/sample-app/src/main/scala/example/usecase/DefaultBoxOfficeUseCase.scala
+++ b/sample-app/src/main/scala/example/usecase/DefaultBoxOfficeUseCase.scala
@@ -12,7 +12,7 @@ object DefaultBoxOfficeUseCase {
 final class DefaultBoxOfficeUseCase(
     boxOfficeService: BoxOfficeService,
 )(implicit
-    dispatcher: DefaultBoxOfficeUseCase.UseCaseExecutionContext,
+    executionContext: DefaultBoxOfficeUseCase.UseCaseExecutionContext,
 ) extends BoxOfficeUseCase {
   import BoxOfficeUseCaseProtocol._
 

--- a/sample-app/src/main/scala/example/usecase/DefaultUseCaseDiDesign.scala
+++ b/sample-app/src/main/scala/example/usecase/DefaultUseCaseDiDesign.scala
@@ -1,6 +1,6 @@
 package example.usecase
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
 import wvlet.airframe.Design
 
 /** UseCase のデフォルト実装定義するDIデザイン
@@ -9,11 +9,12 @@ object DefaultUseCaseDiDesign {
   lazy val design: Design =
     Design.newDesign
       .bind[BoxOfficeUseCase].to[DefaultBoxOfficeUseCase]
-      .bind[DefaultBoxOfficeUseCase.UseCaseExecutionContext].toSingletonProvider[ActorSystem] { system =>
-        system.dispatcher // TODO UseCase用のdispatcherを提供する。
+      .bind[DefaultBoxOfficeUseCase.UseCaseExecutionContext].toSingletonProvider[ActorSystem[Nothing]] { system =>
+        system.executionContext // TODO UseCase用のdispatcherを提供する。
       }
       .bind[BoxOfficeReadModelUseCase].to[DefaultBoxOfficeReadModelUseCase]
-      .bind[DefaultBoxOfficeReadModelUseCase.UseCaseExecutionContext].toSingletonProvider[ActorSystem] { system =>
-        system.dispatcher // TODO UseCase用のdispatcherを提供する。
+      .bind[DefaultBoxOfficeReadModelUseCase.UseCaseExecutionContext].toSingletonProvider[ActorSystem[Nothing]] {
+        system =>
+          system.executionContext // TODO UseCase用のdispatcherを提供する。
       }
 }

--- a/sample-app/src/main/scala/example/usecase/DefaultUseCaseDiDesign.scala
+++ b/sample-app/src/main/scala/example/usecase/DefaultUseCaseDiDesign.scala
@@ -10,11 +10,11 @@ object DefaultUseCaseDiDesign {
     Design.newDesign
       .bind[BoxOfficeUseCase].to[DefaultBoxOfficeUseCase]
       .bind[DefaultBoxOfficeUseCase.UseCaseExecutionContext].toSingletonProvider[ActorSystem[Nothing]] { system =>
-        system.executionContext // TODO UseCase用のdispatcherを提供する。
+        system.executionContext // TODO UseCase用の ExecutionContext を提供する。
       }
       .bind[BoxOfficeReadModelUseCase].to[DefaultBoxOfficeReadModelUseCase]
       .bind[DefaultBoxOfficeReadModelUseCase.UseCaseExecutionContext].toSingletonProvider[ActorSystem[Nothing]] {
         system =>
-          system.executionContext // TODO UseCase用のdispatcherを提供する。
+          system.executionContext // TODO UseCase用の ExecutionContext を提供する。
       }
 }

--- a/sample-app/src/test/scala/example/MainDiDesignSpec.scala
+++ b/sample-app/src/test/scala/example/MainDiDesignSpec.scala
@@ -6,7 +6,7 @@ final class MainDiDesignSpec extends ActorSpecBase(ConfigFactory.load("test-akka
   "MainDiDesign should resolve all dependencies" in {
     // withProductionMode を使用することで、
     // Session を作成できたら、シングルトンの依存関係はすべて解決できていることをテストできる
-    val session = MainDiDesign.design(system.classicSystem).withProductionMode.newSession
+    val session = MainDiDesign.design(system).withProductionMode.newSession
     session.close()
   }
 }

--- a/sample-app/src/test/scala/example/MainDiDesignSpec.scala
+++ b/sample-app/src/test/scala/example/MainDiDesignSpec.scala
@@ -1,0 +1,12 @@
+package example
+
+import com.typesafe.config.ConfigFactory
+
+final class MainDiDesignSpec extends ActorSpecBase(ConfigFactory.load("test-akka-cluster")) {
+  "MainDiDesign should resolve all dependencies" in {
+    // withProductionMode を使用することで、
+    // Session を作成できたら、シングルトンの依存関係はすべて解決できていることをテストできる
+    val session = MainDiDesign.design(system.classicSystem).withProductionMode.newSession
+    session.close()
+  }
+}

--- a/sample-app/src/test/scala/example/application/http/MyBoxOfficeResourceBindSpec.scala
+++ b/sample-app/src/test/scala/example/application/http/MyBoxOfficeResourceBindSpec.scala
@@ -1,6 +1,6 @@
 package example.application.http
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
 import example.ActorSpecBase
 import example.application.http.controller.MyBoxOfficeResource
 import example.testing.tags.ExerciseTest
@@ -15,7 +15,7 @@ final class MyBoxOfficeResourceBindSpec extends ActorSpecBase() with AirframeDiS
 
   override protected val design: Design =
     MainHttpApiServerDiDesign.design
-      .bind[ActorSystem].toInstance(system.classicSystem)
+      .bind[ActorSystem[Nothing]].toInstance(system)
       .bind[BoxOfficeUseCase].toInstance(mock[BoxOfficeUseCase])
       .bind[BoxOfficeReadModelUseCase].toInstance(mock[BoxOfficeReadModelUseCase])
 

--- a/sample-app/src/test/scala/example/model/MyBoxOfficeServiceBindSpec.scala
+++ b/sample-app/src/test/scala/example/model/MyBoxOfficeServiceBindSpec.scala
@@ -1,6 +1,6 @@
 package example.model
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
 import com.typesafe.config.ConfigFactory
 import example.ActorSpecBase
 import example.model.concert.service.{ BoxOfficeService, MyBoxOfficeService }
@@ -14,7 +14,7 @@ final class MyBoxOfficeServiceBindSpec
     with AirframeDiSessionSupport {
   override protected val design: Design =
     ModelDiDesign.design
-      .bind[ActorSystem].toInstance(system.classicSystem)
+      .bind[ActorSystem[Nothing]].toInstance(system)
 
   // 演習で bind 成功を確認するために使用する
   // MyBoxOfficeService のバインドに成功したら success になる

--- a/sample-app/src/test/scala/example/model/MyConcertActorBindSpec.scala
+++ b/sample-app/src/test/scala/example/model/MyConcertActorBindSpec.scala
@@ -1,6 +1,6 @@
 package example.model
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
 import example.ActorSpecBase
 import example.model.concert.actor.{ ConcertActorBehaviorFactory, _ }
 import example.testing.tags.ExerciseTest
@@ -11,7 +11,7 @@ import wvlet.airframe.Design
 final class MyConcertActorBindSpec extends ActorSpecBase() with AirframeDiSessionSupport {
   override protected val design: Design =
     ModelDiDesign.design
-      .bind[ActorSystem].toInstance(system.classicSystem)
+      .bind[ActorSystem[Nothing]].toInstance(system)
 
   // 演習で bind 成功を確認するために使用する
   // MyConcertActor.props のバインドに成功したら success になる

--- a/sample-app/src/test/scala/example/model/concert/service/DefaultBoxOfficeServiceSpec.scala
+++ b/sample-app/src/test/scala/example/model/concert/service/DefaultBoxOfficeServiceSpec.scala
@@ -1,6 +1,6 @@
 package example.model.concert.service
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
 import example.model.ModelDiDesign
 import example.model.concert.actor.ConcertActorClusterShardingFactory
 import testkit.AirframeDiSessionSupport
@@ -12,9 +12,9 @@ final class DefaultBoxOfficeServiceSpec
     with AirframeDiSessionSupport {
   override protected val design: Design =
     ModelDiDesign.design
-      .bind[ActorSystem].toInstance(system.classicSystem)
+      .bind[ActorSystem[Nothing]].toInstance(system)
       .bind[DefaultBoxOfficeService]
-      .toInstanceProvider[ActorSystem, ConcertActorClusterShardingFactory] { (system, factory) =>
+      .toInstanceProvider[ActorSystem[Nothing], ConcertActorClusterShardingFactory] { (system, factory) =>
         new DefaultBoxOfficeService(system, factory)
       }
 

--- a/sample-app/src/test/scala/example/model/concert/service/MyBoxOfficeServiceSpec.scala
+++ b/sample-app/src/test/scala/example/model/concert/service/MyBoxOfficeServiceSpec.scala
@@ -1,6 +1,6 @@
 package example.model.concert.service
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
 import example.model.ModelDiDesign
 import example.model.concert.actor.ConcertActorClusterShardingFactory
 import example.testing.tags.ExerciseTest
@@ -14,9 +14,9 @@ final class MyBoxOfficeServiceSpec
     with AirframeDiSessionSupport {
   override protected val design: Design =
     ModelDiDesign.design
-      .bind[ActorSystem].toInstance(system.classicSystem)
+      .bind[ActorSystem[Nothing]].toInstance(system)
       .bind[MyBoxOfficeService]
-      .toInstanceProvider[ActorSystem, ConcertActorClusterShardingFactory] { (system, factory) =>
+      .toInstanceProvider[ActorSystem[Nothing], ConcertActorClusterShardingFactory] { (system, factory) =>
         new MyBoxOfficeService(system, factory)
       }
 

--- a/sample-app/src/test/scala/example/readmodel/MyConcertRepositoryBindSpec.scala
+++ b/sample-app/src/test/scala/example/readmodel/MyConcertRepositoryBindSpec.scala
@@ -1,6 +1,6 @@
 package example.readmodel
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
 import example.ActorSpecBase
 import example.readmodel.rdb._
 import example.testing.tags.ExerciseTest
@@ -11,7 +11,7 @@ import wvlet.airframe._
 final class MyConcertRepositoryBindSpec extends ActorSpecBase() with AirframeDiSessionSupport {
   override protected val design: Design =
     DefaultReadModelDiDesign.design
-      .bind[ActorSystem].toInstance(system.classicSystem)
+      .bind[ActorSystem[Nothing]].toInstance(system)
 
   // 演習で bind 成功を確認するために使用する
   // MyConcertRepository のバインドに成功したら success になる

--- a/sample-app/src/test/scala/example/readmodel/rdb/DefaultConcertRepositorySpec.scala
+++ b/sample-app/src/test/scala/example/readmodel/rdb/DefaultConcertRepositorySpec.scala
@@ -1,6 +1,6 @@
 package example.readmodel.rdb
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
 import example.readmodel.{ ConcertRepository, DefaultReadModelDiDesign }
 import testkit.AirframeDiSessionSupport
 import wvlet.airframe.Design
@@ -11,7 +11,7 @@ final class DefaultConcertRepositorySpec
     with AirframeDiSessionSupport {
   override protected val design: Design =
     DefaultReadModelDiDesign.design
-      .bind[ActorSystem].toInstance(system.classicSystem)
+      .bind[ActorSystem[Nothing]].toInstance(system)
       .bind[DefaultConcertDatabaseServiceConfig].toInstance(
         new DefaultConcertDatabaseServiceConfig(databaseConfig),
       )

--- a/sample-app/src/test/scala/example/readmodel/rdb/MyConcertRepositorySpec.scala
+++ b/sample-app/src/test/scala/example/readmodel/rdb/MyConcertRepositorySpec.scala
@@ -1,6 +1,6 @@
 package example.readmodel.rdb
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
 import example.readmodel.{ ConcertRepository, DefaultReadModelDiDesign }
 import example.testing.tags.ExerciseTest
 import testkit.AirframeDiSessionSupport
@@ -13,7 +13,7 @@ final class MyConcertRepositorySpec
     with AirframeDiSessionSupport {
   override protected val design: Design =
     DefaultReadModelDiDesign.design
-      .bind[ActorSystem].toInstance(system.classicSystem)
+      .bind[ActorSystem[Nothing]].toInstance(system)
       .bind[DefaultConcertDatabaseServiceConfig].toInstance(
         new DefaultConcertDatabaseServiceConfig(databaseConfig),
       )


### PR DESCRIPTION
サンプルアプリ全体で、Typed ActorSystem を使うようにします。
もし、サンプルアプリ(sample-app/**) の階層以下で、Classic ActorSystem を受け取るものがあれば変更漏れなのでご指摘ください。

sample-app 以外の次のサブプロジェクトは対象ではありません。
- exercise-akka-basic
- exercise-akka-http-basic
- lerna-library
- lerna-testkit