### PR TITLE
ConcertActor のメッセージを整理する

### DIFF
--- a/sample-app/src/main/scala/example/model/concert/actor/ConcertActor.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/ConcertActor.scala
@@ -20,10 +20,11 @@ import example.model.concert._
   */
 object ConcertActor {
 
-  /** ConcertActor へのリクエストメッセージ
+  /** ConcertActor へのリクエスト(コマンド)
+    *
     * シリアライズされる
     */
-  sealed trait ConcertCommandRequest extends KryoSerializable
+  sealed trait Command extends KryoSerializable
 
   /** ConcertActor からのレスポンスメッセージ
     * シリアライズされる
@@ -32,31 +33,29 @@ object ConcertActor {
 
   // --
 
-  case class CreateConcertRequest(numTickets: Int, replyTo: ActorRef[CreateConcertResponse])
-      extends ConcertCommandRequest
-  sealed trait CreateConcertResponse                  extends ConcertCommandResponse
-  case class CreateConcertSucceeded(numTickets: Int)  extends CreateConcertResponse
-  case class CreateConcertFailed(error: ConcertError) extends CreateConcertResponse
+  case class Create(numTickets: Int, replyTo: ActorRef[CreateConcertResponse]) extends Command
+  sealed trait CreateConcertResponse                                           extends ConcertCommandResponse
+  case class CreateConcertSucceeded(numTickets: Int)                           extends CreateConcertResponse
+  case class CreateConcertFailed(error: ConcertError)                          extends CreateConcertResponse
 
   // --
 
-  case class GetConcertRequest(replyTo: ActorRef[GetConcertResponse])                  extends ConcertCommandRequest
+  case class Get(replyTo: ActorRef[GetConcertResponse])                                extends Command
   sealed trait GetConcertResponse                                                      extends ConcertCommandResponse
   case class GetConcertSucceeded(tickets: Vector[ConcertTicketId], cancelled: Boolean) extends GetConcertResponse
   case class GetConcertFailed(error: ConcertError)                                     extends GetConcertResponse
 
   // --
 
-  case class CancelConcertRequest(replyTo: ActorRef[CancelConcertResponse]) extends ConcertCommandRequest
-  sealed trait CancelConcertResponse                                        extends ConcertCommandResponse
-  case class CancelConcertSucceeded(numberOfTickets: Int)                   extends CancelConcertResponse
-  case class CancelConcertFailed(error: ConcertError)                       extends CancelConcertResponse
+  case class Cancel(replyTo: ActorRef[CancelConcertResponse]) extends Command
+  sealed trait CancelConcertResponse                          extends ConcertCommandResponse
+  case class CancelConcertSucceeded(numberOfTickets: Int)     extends CancelConcertResponse
+  case class CancelConcertFailed(error: ConcertError)         extends CancelConcertResponse
 
   // --
 
-  case class BuyConcertTicketsRequest(numberOfTickets: Int, replyTo: ActorRef[BuyConcertTicketsResponse])
-      extends ConcertCommandRequest
-  sealed trait BuyConcertTicketsResponse                                  extends ConcertCommandResponse
-  case class BuyConcertTicketsSucceeded(tickets: Vector[ConcertTicketId]) extends BuyConcertTicketsResponse
-  case class BuyConcertTicketsFailed(error: ConcertError)                 extends BuyConcertTicketsResponse
+  case class BuyTickets(numberOfTickets: Int, replyTo: ActorRef[BuyConcertTicketsResponse]) extends Command
+  sealed trait BuyConcertTicketsResponse                                                    extends ConcertCommandResponse
+  case class BuyConcertTicketsSucceeded(tickets: Vector[ConcertTicketId])                   extends BuyConcertTicketsResponse
+  case class BuyConcertTicketsFailed(error: ConcertError)                                   extends BuyConcertTicketsResponse
 }

--- a/sample-app/src/main/scala/example/model/concert/actor/ConcertActor.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/ConcertActor.scala
@@ -26,36 +26,38 @@ object ConcertActor {
     */
   sealed trait Command extends KryoSerializable
 
-  /** ConcertActor からのレスポンスメッセージ
+  /** ConcertActor からのレスポンス
+    *
     * シリアライズされる
     */
-  sealed trait ConcertCommandResponse extends KryoSerializable
+  sealed trait Response extends KryoSerializable
 
   // --
 
-  case class Create(numTickets: Int, replyTo: ActorRef[CreateConcertResponse]) extends Command
-  sealed trait CreateConcertResponse                                           extends ConcertCommandResponse
-  case class CreateConcertSucceeded(numTickets: Int)                           extends CreateConcertResponse
-  case class CreateConcertFailed(error: ConcertError)                          extends CreateConcertResponse
+  case class Create(numTickets: Int, replyTo: ActorRef[CreateResponse]) extends Command
+  sealed trait CreateResponse                                           extends Response
+  case class CreateSucceeded(numTickets: Int)                           extends CreateResponse
+  case class CreateFailed(error: ConcertError)                          extends CreateResponse
 
   // --
 
-  case class Get(replyTo: ActorRef[GetConcertResponse])                                extends Command
-  sealed trait GetConcertResponse                                                      extends ConcertCommandResponse
-  case class GetConcertSucceeded(tickets: Vector[ConcertTicketId], cancelled: Boolean) extends GetConcertResponse
-  case class GetConcertFailed(error: ConcertError)                                     extends GetConcertResponse
+  case class Get(replyTo: ActorRef[GetResponse])                                extends Command
+  sealed trait GetResponse                                                      extends Response
+  case class GetSucceeded(tickets: Vector[ConcertTicketId], cancelled: Boolean) extends GetResponse
+  case class GetFailed(error: ConcertError)                                     extends GetResponse
 
   // --
 
-  case class Cancel(replyTo: ActorRef[CancelConcertResponse]) extends Command
-  sealed trait CancelConcertResponse                          extends ConcertCommandResponse
-  case class CancelConcertSucceeded(numberOfTickets: Int)     extends CancelConcertResponse
-  case class CancelConcertFailed(error: ConcertError)         extends CancelConcertResponse
+  case class Cancel(replyTo: ActorRef[CancelResponse]) extends Command
+  sealed trait CancelResponse                          extends Response
+  case class CancelSucceeded(numberOfTickets: Int)     extends CancelResponse
+  case class CancelFailed(error: ConcertError)         extends CancelResponse
 
   // --
 
-  case class BuyTickets(numberOfTickets: Int, replyTo: ActorRef[BuyConcertTicketsResponse]) extends Command
-  sealed trait BuyConcertTicketsResponse                                                    extends ConcertCommandResponse
-  case class BuyConcertTicketsSucceeded(tickets: Vector[ConcertTicketId])                   extends BuyConcertTicketsResponse
-  case class BuyConcertTicketsFailed(error: ConcertError)                                   extends BuyConcertTicketsResponse
+  case class BuyTickets(numberOfTickets: Int, replyTo: ActorRef[BuyTicketsResponse]) extends Command
+  sealed trait BuyTicketsResponse                                                    extends Response
+  case class BuyTicketsSucceeded(tickets: Vector[ConcertTicketId])                   extends BuyTicketsResponse
+  case class BuyTicketsFailed(error: ConcertError)                                   extends BuyTicketsResponse
+
 }

--- a/sample-app/src/main/scala/example/model/concert/actor/ConcertActor.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/ConcertActor.scala
@@ -34,30 +34,30 @@ object ConcertActor {
 
   // --
 
-  case class Create(numTickets: Int, replyTo: ActorRef[CreateResponse]) extends Command
-  sealed trait CreateResponse                                           extends Response
-  case class CreateSucceeded(numTickets: Int)                           extends CreateResponse
-  case class CreateFailed(error: ConcertError)                          extends CreateResponse
+  final case class Create(numTickets: Int, replyTo: ActorRef[CreateResponse]) extends Command
+  sealed trait CreateResponse                                                 extends Response
+  final case class CreateSucceeded(numTickets: Int)                           extends CreateResponse
+  final case class CreateFailed(error: ConcertError)                          extends CreateResponse
 
   // --
 
-  case class Get(replyTo: ActorRef[GetResponse])                                extends Command
-  sealed trait GetResponse                                                      extends Response
-  case class GetSucceeded(tickets: Vector[ConcertTicketId], cancelled: Boolean) extends GetResponse
-  case class GetFailed(error: ConcertError)                                     extends GetResponse
+  final case class Get(replyTo: ActorRef[GetResponse])                                extends Command
+  sealed trait GetResponse                                                            extends Response
+  final case class GetSucceeded(tickets: Vector[ConcertTicketId], cancelled: Boolean) extends GetResponse
+  final case class GetFailed(error: ConcertError)                                     extends GetResponse
 
   // --
 
-  case class Cancel(replyTo: ActorRef[CancelResponse]) extends Command
-  sealed trait CancelResponse                          extends Response
-  case class CancelSucceeded(numberOfTickets: Int)     extends CancelResponse
-  case class CancelFailed(error: ConcertError)         extends CancelResponse
+  final case class Cancel(replyTo: ActorRef[CancelResponse]) extends Command
+  sealed trait CancelResponse                                extends Response
+  final case class CancelSucceeded(numberOfTickets: Int)     extends CancelResponse
+  final case class CancelFailed(error: ConcertError)         extends CancelResponse
 
   // --
 
-  case class BuyTickets(numberOfTickets: Int, replyTo: ActorRef[BuyTicketsResponse]) extends Command
-  sealed trait BuyTicketsResponse                                                    extends Response
-  case class BuyTicketsSucceeded(tickets: Vector[ConcertTicketId])                   extends BuyTicketsResponse
-  case class BuyTicketsFailed(error: ConcertError)                                   extends BuyTicketsResponse
+  final case class BuyTickets(numberOfTickets: Int, replyTo: ActorRef[BuyTicketsResponse]) extends Command
+  sealed trait BuyTicketsResponse                                                          extends Response
+  final case class BuyTicketsSucceeded(tickets: Vector[ConcertTicketId])                   extends BuyTicketsResponse
+  final case class BuyTicketsFailed(error: ConcertError)                                   extends BuyTicketsResponse
 
 }

--- a/sample-app/src/main/scala/example/model/concert/actor/ConcertActor.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/ConcertActor.scala
@@ -4,9 +4,21 @@ import akka.actor.typed.ActorRef
 import example.model.KryoSerializable
 import example.model.concert._
 
-/** ConcertActor の入出力を定義する
+/** このサンプルアプリでは、テストコードの共通化などを目的として、
+  * 次の3つの Behavior のプロトコルを [[ConcertActor]] にて共通で定義している。
+  *  - [[DefaultConcertActor]]
+  *  - [[MyConcertActor]]
+  *  - [[DefaultConcertActorWithEventPersistence]]
+  *
+  * この方法は一般的な方法ではなく、特殊な方法になっていることに注意すること。
+  *
+  * 一般的な方法に従うと、Behavior の定義と一緒に入力プロトコルを定義することになる。
+  * 例えば次のようになる。
+  *   - `DefaultConcertActor.Command`
+  *   - `MyConcertActor.Command`
+  *   - `DefaultConcertActorWithEventPersistence.Command`
   */
-object ConcertActorProtocol {
+object ConcertActor {
 
   /** ConcertActor へのリクエストメッセージ
     * シリアライズされる

--- a/sample-app/src/main/scala/example/model/concert/actor/ConcertActorBehaviorFactory.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/ConcertActorBehaviorFactory.scala
@@ -3,7 +3,7 @@ package example.model.concert.actor
 import akka.actor.typed.Behavior
 import akka.persistence.typed.PersistenceId
 import example.model.concert.ConcertId
-import example.model.concert.actor.ConcertActorProtocol.ConcertCommandRequest
+import example.model.concert.actor.ConcertActor.ConcertCommandRequest
 
 trait ConcertActorBehaviorFactory {
   def apply(id: ConcertId, persistenceId: PersistenceId): Behavior[ConcertCommandRequest]

--- a/sample-app/src/main/scala/example/model/concert/actor/ConcertActorBehaviorFactory.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/ConcertActorBehaviorFactory.scala
@@ -3,8 +3,8 @@ package example.model.concert.actor
 import akka.actor.typed.Behavior
 import akka.persistence.typed.PersistenceId
 import example.model.concert.ConcertId
-import example.model.concert.actor.ConcertActor.Command
+import example.model.concert.actor.ConcertActor
 
 trait ConcertActorBehaviorFactory {
-  def apply(id: ConcertId, persistenceId: PersistenceId): Behavior[Command]
+  def apply(id: ConcertId, persistenceId: PersistenceId): Behavior[ConcertActor.Command]
 }

--- a/sample-app/src/main/scala/example/model/concert/actor/ConcertActorBehaviorFactory.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/ConcertActorBehaviorFactory.scala
@@ -3,8 +3,8 @@ package example.model.concert.actor
 import akka.actor.typed.Behavior
 import akka.persistence.typed.PersistenceId
 import example.model.concert.ConcertId
-import example.model.concert.actor.ConcertActor.ConcertCommandRequest
+import example.model.concert.actor.ConcertActor.Command
 
 trait ConcertActorBehaviorFactory {
-  def apply(id: ConcertId, persistenceId: PersistenceId): Behavior[ConcertCommandRequest]
+  def apply(id: ConcertId, persistenceId: PersistenceId): Behavior[Command]
 }

--- a/sample-app/src/main/scala/example/model/concert/actor/ConcertActorClusterSharding.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/ConcertActorClusterSharding.scala
@@ -4,7 +4,7 @@ import akka.actor.typed.ActorSystem
 import akka.cluster.sharding.typed.scaladsl.{ ClusterSharding, Entity, EntityRef, EntityTypeKey }
 import akka.persistence.typed.PersistenceId
 import example.model.concert.ConcertId
-import example.model.concert.actor.ConcertActor.ConcertCommandRequest
+import example.model.concert.actor.ConcertActor.Command
 
 /** ConcertActor の ClusterSharding を管理する
   */
@@ -13,8 +13,8 @@ final class ConcertActorClusterSharding(
     createBehavior: ConcertActorBehaviorFactory,
 ) {
   private val sharding = ClusterSharding(system)
-  private val TypeKey: EntityTypeKey[ConcertCommandRequest] =
-    EntityTypeKey[ConcertCommandRequest]("concerts")
+  private val TypeKey: EntityTypeKey[Command] =
+    EntityTypeKey[Command]("concerts")
 
   sharding.init(Entity(TypeKey) { entityContext =>
     val id = ConcertId
@@ -25,7 +25,7 @@ final class ConcertActorClusterSharding(
     createBehavior(id, persistenceId)
   })
 
-  def entityRefFor(id: ConcertId): EntityRef[ConcertCommandRequest] = {
+  def entityRefFor(id: ConcertId): EntityRef[Command] = {
     sharding.entityRefFor(TypeKey, id.value)
   }
 }

--- a/sample-app/src/main/scala/example/model/concert/actor/ConcertActorClusterSharding.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/ConcertActorClusterSharding.scala
@@ -4,7 +4,7 @@ import akka.actor.typed.ActorSystem
 import akka.cluster.sharding.typed.scaladsl.{ ClusterSharding, Entity, EntityRef, EntityTypeKey }
 import akka.persistence.typed.PersistenceId
 import example.model.concert.ConcertId
-import example.model.concert.actor.ConcertActor.Command
+import example.model.concert.actor.ConcertActor
 
 /** ConcertActor の ClusterSharding を管理する
   */
@@ -13,8 +13,8 @@ final class ConcertActorClusterSharding(
     createBehavior: ConcertActorBehaviorFactory,
 ) {
   private val sharding = ClusterSharding(system)
-  private val TypeKey: EntityTypeKey[Command] =
-    EntityTypeKey[Command]("concerts")
+  private val TypeKey: EntityTypeKey[ConcertActor.Command] =
+    EntityTypeKey[ConcertActor.Command]("concerts")
 
   sharding.init(Entity(TypeKey) { entityContext =>
     val id = ConcertId
@@ -25,7 +25,7 @@ final class ConcertActorClusterSharding(
     createBehavior(id, persistenceId)
   })
 
-  def entityRefFor(id: ConcertId): EntityRef[Command] = {
+  def entityRefFor(id: ConcertId): EntityRef[ConcertActor.Command] = {
     sharding.entityRefFor(TypeKey, id.value)
   }
 }

--- a/sample-app/src/main/scala/example/model/concert/actor/ConcertActorClusterSharding.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/ConcertActorClusterSharding.scala
@@ -4,7 +4,7 @@ import akka.actor.typed.ActorSystem
 import akka.cluster.sharding.typed.scaladsl.{ ClusterSharding, Entity, EntityRef, EntityTypeKey }
 import akka.persistence.typed.PersistenceId
 import example.model.concert.ConcertId
-import example.model.concert.actor.ConcertActorProtocol.ConcertCommandRequest
+import example.model.concert.actor.ConcertActor.ConcertCommandRequest
 
 /** ConcertActor の ClusterSharding を管理する
   */

--- a/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActor.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActor.scala
@@ -7,7 +7,7 @@ import example.model.KryoSerializable
 import example.model.concert.ConcertError._
 import example.model.concert.ConcertEvent.{ ConcertCancelled, ConcertCreated, ConcertTicketsBought }
 import example.model.concert._
-import example.model.concert.actor.ConcertActorProtocol._
+import example.model.concert.actor.ConcertActor._
 
 import java.time.ZonedDateTime
 

--- a/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActor.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActor.scala
@@ -39,24 +39,24 @@ object DefaultConcertActor extends ConcertActorBehaviorFactory {
       command match {
         case getRequest: Get =>
           // 未作成なのでエラー
-          Effect.reply(getRequest.replyTo)(GetConcertFailed(ConcertNotFoundError(id)))
+          Effect.reply(getRequest.replyTo)(GetFailed(ConcertNotFoundError(id)))
         case createRequest: Create =>
           // 作成イベントを発行する処理
           if (createRequest.numTickets <= 0) {
             // チケット数が0枚以下なのでエラー
             val error = InvalidConcertOperationError("Cannot create concert without tickets.")
-            Effect.reply(createRequest.replyTo)(CreateConcertFailed(error))
+            Effect.reply(createRequest.replyTo)(CreateFailed(error))
           } else {
             // 作成成功
             val event = ConcertCreated(id, createRequest.numTickets, ZonedDateTime.now)
-            Effect.persist(event).thenReply(createRequest.replyTo)(_ => CreateConcertSucceeded(event.numOfTickets))
+            Effect.persist(event).thenReply(createRequest.replyTo)(_ => CreateSucceeded(event.numOfTickets))
           }
         case cancelRequest: Cancel =>
           // 未作成なのでエラー
-          Effect.reply(cancelRequest.replyTo)(CancelConcertFailed(ConcertNotFoundError(id)))
+          Effect.reply(cancelRequest.replyTo)(CancelFailed(ConcertNotFoundError(id)))
         case buyTicketsRequest: BuyTickets =>
           // 未作成なのでエラー
-          Effect.reply(buyTicketsRequest.replyTo)(BuyConcertTicketsFailed(ConcertNotFoundError(id)))
+          Effect.reply(buyTicketsRequest.replyTo)(BuyTicketsFailed(ConcertNotFoundError(id)))
       }
     }
     override def applyEvent(event: ConcertEvent): State = {
@@ -76,28 +76,28 @@ object DefaultConcertActor extends ConcertActorBehaviorFactory {
     override def applyCommand(command: Command): ReplyEffect = {
       command match {
         case getRequest: Get =>
-          Effect.reply(getRequest.replyTo)(GetConcertSucceeded(tickets, cancelled = false))
+          Effect.reply(getRequest.replyTo)(GetSucceeded(tickets, cancelled = false))
         case createRequest: Create =>
           // 既に作成済みなのでエラー
-          Effect.reply(createRequest.replyTo)(CreateConcertFailed(DuplicatedConcertError(id)))
+          Effect.reply(createRequest.replyTo)(CreateFailed(DuplicatedConcertError(id)))
         case cancelRequest: Cancel =>
           // キャンセル処理を実行する
           val event = ConcertCancelled(id, ZonedDateTime.now)
-          Effect.persist(event).thenReply(cancelRequest.replyTo)(_ => CancelConcertSucceeded(tickets.size))
+          Effect.persist(event).thenReply(cancelRequest.replyTo)(_ => CancelSucceeded(tickets.size))
         case buyTicketsRequest: BuyTickets =>
           // チケット購入処理
           if (buyTicketsRequest.numberOfTickets <= 0) {
             // チケット枚数がゼロ以下なのでエラー
             val error = InvalidConcertOperationError("Cannot a buy non positive number of tickets.")
-            Effect.reply(buyTicketsRequest.replyTo)(BuyConcertTicketsFailed(error))
+            Effect.reply(buyTicketsRequest.replyTo)(BuyTicketsFailed(error))
           } else if (buyTicketsRequest.numberOfTickets > tickets.size) {
             // 残チケット枚数が不足しているのでエラー
             val error = InvalidConcertOperationError("Not enough tickets available.")
-            Effect.reply(buyTicketsRequest.replyTo)(BuyConcertTicketsFailed(error))
+            Effect.reply(buyTicketsRequest.replyTo)(BuyTicketsFailed(error))
           } else {
             val boughtTickets = tickets.take(buyTicketsRequest.numberOfTickets)
             val event         = ConcertTicketsBought(id, boughtTickets, ZonedDateTime.now)
-            Effect.persist(event).thenReply(buyTicketsRequest.replyTo)(_ => BuyConcertTicketsSucceeded(event.tickets))
+            Effect.persist(event).thenReply(buyTicketsRequest.replyTo)(_ => BuyTicketsSucceeded(event.tickets))
           }
       }
     }
@@ -123,18 +123,18 @@ object DefaultConcertActor extends ConcertActorBehaviorFactory {
       command match {
         case getRequest: Get =>
           // 取得処理は成功する
-          Effect.reply(getRequest.replyTo)(GetConcertSucceeded(tickets, cancelled = true))
+          Effect.reply(getRequest.replyTo)(GetSucceeded(tickets, cancelled = true))
         case createRequest: Create =>
           // すでにコンサートが存在するのでエラー
-          Effect.reply(createRequest.replyTo)(CreateConcertFailed(DuplicatedConcertError(id)))
+          Effect.reply(createRequest.replyTo)(CreateFailed(DuplicatedConcertError(id)))
         case cancelRequest: Cancel =>
           // すでにキャンセル済みなのでエラー
           val error = InvalidConcertOperationError("Concert is already cancelled.")
-          Effect.reply(cancelRequest.replyTo)(CancelConcertFailed(error))
+          Effect.reply(cancelRequest.replyTo)(CancelFailed(error))
         case buyTicketsRequest: BuyTickets =>
           // すでにキャンセル済みなのでエラー
           val error = InvalidConcertOperationError("Concert is already cancelled.")
-          Effect.reply(buyTicketsRequest.replyTo)(BuyConcertTicketsFailed(error))
+          Effect.reply(buyTicketsRequest.replyTo)(BuyTicketsFailed(error))
       }
     }
     override def applyEvent(event: ConcertEvent): State = {

--- a/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActor.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActor.scala
@@ -12,9 +12,9 @@ import example.model.concert.actor.ConcertActor._
 import java.time.ZonedDateTime
 
 object DefaultConcertActor extends ConcertActorBehaviorFactory {
-  def apply(id: ConcertId, persistenceId: PersistenceId): Behavior[ConcertCommandRequest] = {
+  def apply(id: ConcertId, persistenceId: PersistenceId): Behavior[Command] = {
     EventSourcedBehavior
-      .withEnforcedReplies[ConcertCommandRequest, ConcertEvent, State](
+      .withEnforcedReplies[Command, ConcertEvent, State](
         persistenceId,
         emptyState = NoConcertState(id),
         (state, command) => state.applyCommand(command),
@@ -29,18 +29,18 @@ object DefaultConcertActor extends ConcertActorBehaviorFactory {
 
   type ReplyEffect = akka.persistence.typed.scaladsl.ReplyEffect[ConcertEvent, State]
   sealed trait State extends KryoSerializable {
-    def applyCommand(command: ConcertCommandRequest): ReplyEffect
+    def applyCommand(command: Command): ReplyEffect
     def applyEvent(event: ConcertEvent): State
   }
 
   /** コンサートが存在しない場合 */
   final case class NoConcertState(id: ConcertId) extends State {
-    override def applyCommand(command: ConcertCommandRequest): ReplyEffect = {
+    override def applyCommand(command: Command): ReplyEffect = {
       command match {
-        case getRequest: GetConcertRequest =>
+        case getRequest: Get =>
           // 未作成なのでエラー
           Effect.reply(getRequest.replyTo)(GetConcertFailed(ConcertNotFoundError(id)))
-        case createRequest: CreateConcertRequest =>
+        case createRequest: Create =>
           // 作成イベントを発行する処理
           if (createRequest.numTickets <= 0) {
             // チケット数が0枚以下なのでエラー
@@ -51,10 +51,10 @@ object DefaultConcertActor extends ConcertActorBehaviorFactory {
             val event = ConcertCreated(id, createRequest.numTickets, ZonedDateTime.now)
             Effect.persist(event).thenReply(createRequest.replyTo)(_ => CreateConcertSucceeded(event.numOfTickets))
           }
-        case cancelRequest: CancelConcertRequest =>
+        case cancelRequest: Cancel =>
           // 未作成なのでエラー
           Effect.reply(cancelRequest.replyTo)(CancelConcertFailed(ConcertNotFoundError(id)))
-        case buyTicketsRequest: BuyConcertTicketsRequest =>
+        case buyTicketsRequest: BuyTickets =>
           // 未作成なのでエラー
           Effect.reply(buyTicketsRequest.replyTo)(BuyConcertTicketsFailed(ConcertNotFoundError(id)))
       }
@@ -73,18 +73,18 @@ object DefaultConcertActor extends ConcertActorBehaviorFactory {
 
   /** コンサートが存在する場合(未キャンセル) */
   final case class AvailableConcertState(id: ConcertId, tickets: Vector[ConcertTicketId]) extends State {
-    override def applyCommand(command: ConcertCommandRequest): ReplyEffect = {
+    override def applyCommand(command: Command): ReplyEffect = {
       command match {
-        case getRequest: GetConcertRequest =>
+        case getRequest: Get =>
           Effect.reply(getRequest.replyTo)(GetConcertSucceeded(tickets, cancelled = false))
-        case createRequest: CreateConcertRequest =>
+        case createRequest: Create =>
           // 既に作成済みなのでエラー
           Effect.reply(createRequest.replyTo)(CreateConcertFailed(DuplicatedConcertError(id)))
-        case cancelRequest: CancelConcertRequest =>
+        case cancelRequest: Cancel =>
           // キャンセル処理を実行する
           val event = ConcertCancelled(id, ZonedDateTime.now)
           Effect.persist(event).thenReply(cancelRequest.replyTo)(_ => CancelConcertSucceeded(tickets.size))
-        case buyTicketsRequest: BuyConcertTicketsRequest =>
+        case buyTicketsRequest: BuyTickets =>
           // チケット購入処理
           if (buyTicketsRequest.numberOfTickets <= 0) {
             // チケット枚数がゼロ以下なのでエラー
@@ -119,19 +119,19 @@ object DefaultConcertActor extends ConcertActorBehaviorFactory {
   /** コンサートが存在する場合(キャンセル済み)
     */
   final case class CancelledConcertState(id: ConcertId, tickets: Vector[ConcertTicketId]) extends State {
-    override def applyCommand(command: ConcertCommandRequest): ReplyEffect = {
+    override def applyCommand(command: Command): ReplyEffect = {
       command match {
-        case getRequest: GetConcertRequest =>
+        case getRequest: Get =>
           // 取得処理は成功する
           Effect.reply(getRequest.replyTo)(GetConcertSucceeded(tickets, cancelled = true))
-        case createRequest: CreateConcertRequest =>
+        case createRequest: Create =>
           // すでにコンサートが存在するのでエラー
           Effect.reply(createRequest.replyTo)(CreateConcertFailed(DuplicatedConcertError(id)))
-        case cancelRequest: CancelConcertRequest =>
+        case cancelRequest: Cancel =>
           // すでにキャンセル済みなのでエラー
           val error = InvalidConcertOperationError("Concert is already cancelled.")
           Effect.reply(cancelRequest.replyTo)(CancelConcertFailed(error))
-        case buyTicketsRequest: BuyConcertTicketsRequest =>
+        case buyTicketsRequest: BuyTickets =>
           // すでにキャンセル済みなのでエラー
           val error = InvalidConcertOperationError("Concert is already cancelled.")
           Effect.reply(buyTicketsRequest.replyTo)(BuyConcertTicketsFailed(error))

--- a/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActorWithEventPersistence.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActorWithEventPersistence.scala
@@ -33,26 +33,26 @@ object DefaultConcertActorWithEventPersistence extends ConcertActorBehaviorFacto
   final case class NoConcertState(id: ConcertId) extends State {
     override def applyCommand(command: Command): ReplyEffect = {
       command match {
-        case getRequest: Get =>
+        case getCommand: Get =>
           // 未作成なのでエラー
-          Effect.reply(getRequest.replyTo)(GetFailed(ConcertNotFoundError(id)))
-        case createRequest: Create =>
+          Effect.reply(getCommand.replyTo)(GetFailed(ConcertNotFoundError(id)))
+        case createCommand: Create =>
           // 作成イベントを発行する処理
-          if (createRequest.numTickets <= 0) {
+          if (createCommand.numTickets <= 0) {
             // チケット数が0枚以下なのでエラー
             val error = InvalidConcertOperationError("Cannot create concert without tickets.")
-            Effect.reply(createRequest.replyTo)(CreateFailed(error))
+            Effect.reply(createCommand.replyTo)(CreateFailed(error))
           } else {
             // 作成成功
-            val event = ConcertCreated(id, createRequest.numTickets, ZonedDateTime.now)
-            Effect.persist(event).thenReply(createRequest.replyTo)(_ => CreateSucceeded(event.numOfTickets))
+            val event = ConcertCreated(id, createCommand.numTickets, ZonedDateTime.now)
+            Effect.persist(event).thenReply(createCommand.replyTo)(_ => CreateSucceeded(event.numOfTickets))
           }
-        case cancelRequest: Cancel =>
+        case cancelCommand: Cancel =>
           // 未作成なのでエラー
-          Effect.reply(cancelRequest.replyTo)(CancelFailed(ConcertNotFoundError(id)))
-        case buyTicketsRequest: BuyTickets =>
+          Effect.reply(cancelCommand.replyTo)(CancelFailed(ConcertNotFoundError(id)))
+        case buyTicketsCommand: BuyTickets =>
           // 未作成なのでエラー
-          Effect.reply(buyTicketsRequest.replyTo)(BuyTicketsFailed(ConcertNotFoundError(id)))
+          Effect.reply(buyTicketsCommand.replyTo)(BuyTicketsFailed(ConcertNotFoundError(id)))
       }
     }
     override def applyEvent(event: ConcertEvent): State = {
@@ -71,29 +71,29 @@ object DefaultConcertActorWithEventPersistence extends ConcertActorBehaviorFacto
   final case class AvailableConcertState(id: ConcertId, tickets: Vector[ConcertTicketId]) extends State {
     override def applyCommand(command: Command): ReplyEffect = {
       command match {
-        case getRequest: Get =>
-          Effect.reply(getRequest.replyTo)(GetSucceeded(tickets, cancelled = false))
-        case createRequest: Create =>
+        case getCommand: Get =>
+          Effect.reply(getCommand.replyTo)(GetSucceeded(tickets, cancelled = false))
+        case createCommand: Create =>
           // 既に作成済みなのでエラー
-          Effect.reply(createRequest.replyTo)(CreateFailed(DuplicatedConcertError(id)))
-        case cancelRequest: Cancel =>
+          Effect.reply(createCommand.replyTo)(CreateFailed(DuplicatedConcertError(id)))
+        case cancelCommand: Cancel =>
           // キャンセル処理を実行する
           val event = ConcertCancelled(id, ZonedDateTime.now)
-          Effect.persist(event).thenReply(cancelRequest.replyTo)(_ => CancelSucceeded(tickets.size))
-        case buyTicketsRequest: BuyTickets =>
+          Effect.persist(event).thenReply(cancelCommand.replyTo)(_ => CancelSucceeded(tickets.size))
+        case buyTicketsCommand: BuyTickets =>
           // チケット購入処理
-          if (buyTicketsRequest.numberOfTickets <= 0) {
+          if (buyTicketsCommand.numberOfTickets <= 0) {
             // チケット枚数がゼロ以下なのでエラー
             val error = InvalidConcertOperationError("Cannot a buy non positive number of tickets.")
-            Effect.reply(buyTicketsRequest.replyTo)(BuyTicketsFailed(error))
-          } else if (buyTicketsRequest.numberOfTickets > tickets.size) {
+            Effect.reply(buyTicketsCommand.replyTo)(BuyTicketsFailed(error))
+          } else if (buyTicketsCommand.numberOfTickets > tickets.size) {
             // 残チケット枚数が不足しているのでエラー
             val error = InvalidConcertOperationError("Not enough tickets available.")
-            Effect.reply(buyTicketsRequest.replyTo)(BuyTicketsFailed(error))
+            Effect.reply(buyTicketsCommand.replyTo)(BuyTicketsFailed(error))
           } else {
-            val boughtTickets = tickets.take(buyTicketsRequest.numberOfTickets)
+            val boughtTickets = tickets.take(buyTicketsCommand.numberOfTickets)
             val event         = ConcertTicketsBought(id, boughtTickets, ZonedDateTime.now)
-            Effect.persist(event).thenReply(buyTicketsRequest.replyTo)(_ => BuyTicketsSucceeded(event.tickets))
+            Effect.persist(event).thenReply(buyTicketsCommand.replyTo)(_ => BuyTicketsSucceeded(event.tickets))
           }
       }
     }
@@ -117,20 +117,20 @@ object DefaultConcertActorWithEventPersistence extends ConcertActorBehaviorFacto
   final case class CancelledConcertState(id: ConcertId, tickets: Vector[ConcertTicketId]) extends State {
     override def applyCommand(command: Command): ReplyEffect = {
       command match {
-        case getRequest: Get =>
+        case getCommand: Get =>
           // 取得処理は成功する
-          Effect.reply(getRequest.replyTo)(GetSucceeded(tickets, cancelled = true))
-        case createRequest: Create =>
+          Effect.reply(getCommand.replyTo)(GetSucceeded(tickets, cancelled = true))
+        case createCommand: Create =>
           // すでにコンサートが存在するのでエラー
-          Effect.reply(createRequest.replyTo)(CreateFailed(DuplicatedConcertError(id)))
-        case cancelRequest: Cancel =>
+          Effect.reply(createCommand.replyTo)(CreateFailed(DuplicatedConcertError(id)))
+        case cancelCommand: Cancel =>
           // すでにキャンセル済みなのでエラー
           val error = InvalidConcertOperationError("Concert is already cancelled.")
-          Effect.reply(cancelRequest.replyTo)(CancelFailed(error))
-        case buyTicketsRequest: BuyTickets =>
+          Effect.reply(cancelCommand.replyTo)(CancelFailed(error))
+        case buyTicketsCommand: BuyTickets =>
           // すでにキャンセル済みなのでエラー
           val error = InvalidConcertOperationError("Concert is already cancelled.")
-          Effect.reply(buyTicketsRequest.replyTo)(BuyTicketsFailed(error))
+          Effect.reply(buyTicketsCommand.replyTo)(BuyTicketsFailed(error))
       }
     }
     override def applyEvent(event: ConcertEvent): State = {

--- a/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActorWithEventPersistence.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/DefaultConcertActorWithEventPersistence.scala
@@ -7,7 +7,7 @@ import example.model.KryoSerializable
 import example.model.concert.ConcertError._
 import example.model.concert.ConcertEvent._
 import example.model.concert._
-import example.model.concert.actor.ConcertActorProtocol._
+import example.model.concert.actor.ConcertActor._
 
 import java.time.ZonedDateTime
 

--- a/sample-app/src/main/scala/example/model/concert/actor/MyConcertActor.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/MyConcertActor.scala
@@ -5,7 +5,7 @@ import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.scaladsl.EventSourcedBehavior
 import example.model.KryoSerializable
 import example.model.concert._
-import example.model.concert.actor.ConcertActorProtocol._
+import example.model.concert.actor.ConcertActor._
 
 object MyConcertActor extends ConcertActorBehaviorFactory {
   def apply(id: ConcertId, persistenceId: PersistenceId): Behavior[ConcertCommandRequest] = {

--- a/sample-app/src/main/scala/example/model/concert/actor/MyConcertActor.scala
+++ b/sample-app/src/main/scala/example/model/concert/actor/MyConcertActor.scala
@@ -8,9 +8,9 @@ import example.model.concert._
 import example.model.concert.actor.ConcertActor._
 
 object MyConcertActor extends ConcertActorBehaviorFactory {
-  def apply(id: ConcertId, persistenceId: PersistenceId): Behavior[ConcertCommandRequest] = {
+  def apply(id: ConcertId, persistenceId: PersistenceId): Behavior[Command] = {
     EventSourcedBehavior
-      .withEnforcedReplies[ConcertCommandRequest, ConcertEvent, State](
+      .withEnforcedReplies[Command, ConcertEvent, State](
         persistenceId,
         emptyState = NoConcertState(id),
         (state, command) => state.applyCommand(command),
@@ -21,26 +21,26 @@ object MyConcertActor extends ConcertActorBehaviorFactory {
 
   type ReplyEffect = akka.persistence.typed.scaladsl.ReplyEffect[ConcertEvent, State]
   sealed trait State extends KryoSerializable {
-    def applyCommand(command: ConcertCommandRequest): ReplyEffect
+    def applyCommand(command: Command): ReplyEffect
     def applyEvent(event: ConcertEvent): State
   }
 
   /** コンサートが存在しない場合 */
   final case class NoConcertState(id: ConcertId) extends State {
-    override def applyCommand(command: ConcertCommandRequest): ReplyEffect = ???
-    override def applyEvent(event: ConcertEvent): State                    = ???
+    override def applyCommand(command: Command): ReplyEffect = ???
+    override def applyEvent(event: ConcertEvent): State      = ???
   }
 
   /** コンサートが存在する場合(未キャンセル) */
   final case class AvailableConcertState(id: ConcertId, tickets: Vector[ConcertTicketId]) extends State {
-    override def applyCommand(command: ConcertCommandRequest): ReplyEffect = ???
-    override def applyEvent(event: ConcertEvent): State                    = ???
+    override def applyCommand(command: Command): ReplyEffect = ???
+    override def applyEvent(event: ConcertEvent): State      = ???
   }
 
   /** コンサートが存在する場合(キャンセル済み) */
   final case class CancelledConcertState(id: ConcertId, tickets: Vector[ConcertTicketId]) extends State {
-    override def applyCommand(command: ConcertCommandRequest): ReplyEffect = ???
-    override def applyEvent(event: ConcertEvent): State                    = ???
+    override def applyCommand(command: Command): ReplyEffect = ???
+    override def applyEvent(event: ConcertEvent): State      = ???
   }
 
 }

--- a/sample-app/src/main/scala/example/model/concert/service/BoxOfficeService.scala
+++ b/sample-app/src/main/scala/example/model/concert/service/BoxOfficeService.scala
@@ -1,7 +1,7 @@
 package example.model.concert.service
 
 import example.model.concert.ConcertId
-import example.model.concert.actor.ConcertActor._
+import example.model.concert.actor.ConcertActor
 
 import scala.concurrent.Future
 
@@ -9,17 +9,17 @@ trait BoxOfficeService {
 
   /** コンサートを作成する。
     */
-  def createConcert(id: ConcertId, numberOfTickets: Int): Future[CreateResponse]
+  def createConcert(id: ConcertId, numberOfTickets: Int): Future[ConcertActor.CreateResponse]
 
   /** コンサートを取得する。
     */
-  def getConcert(id: ConcertId): Future[GetResponse]
+  def getConcert(id: ConcertId): Future[ConcertActor.GetResponse]
 
   /** コンサートをキャンセルする。
     */
-  def cancelConcert(id: ConcertId): Future[CancelResponse]
+  def cancelConcert(id: ConcertId): Future[ConcertActor.CancelResponse]
 
   /** コンサートのチケットを購入する。
     */
-  def buyConcertTickets(id: ConcertId, numberOfTickets: Int): Future[BuyTicketsResponse]
+  def buyConcertTickets(id: ConcertId, numberOfTickets: Int): Future[ConcertActor.BuyTicketsResponse]
 }

--- a/sample-app/src/main/scala/example/model/concert/service/BoxOfficeService.scala
+++ b/sample-app/src/main/scala/example/model/concert/service/BoxOfficeService.scala
@@ -9,17 +9,17 @@ trait BoxOfficeService {
 
   /** コンサートを作成する。
     */
-  def createConcert(id: ConcertId, numberOfTickets: Int): Future[CreateConcertResponse]
+  def createConcert(id: ConcertId, numberOfTickets: Int): Future[CreateResponse]
 
   /** コンサートを取得する。
     */
-  def getConcert(id: ConcertId): Future[GetConcertResponse]
+  def getConcert(id: ConcertId): Future[GetResponse]
 
   /** コンサートをキャンセルする。
     */
-  def cancelConcert(id: ConcertId): Future[CancelConcertResponse]
+  def cancelConcert(id: ConcertId): Future[CancelResponse]
 
   /** コンサートのチケットを購入する。
     */
-  def buyConcertTickets(id: ConcertId, numberOfTickets: Int): Future[BuyConcertTicketsResponse]
+  def buyConcertTickets(id: ConcertId, numberOfTickets: Int): Future[BuyTicketsResponse]
 }

--- a/sample-app/src/main/scala/example/model/concert/service/BoxOfficeService.scala
+++ b/sample-app/src/main/scala/example/model/concert/service/BoxOfficeService.scala
@@ -1,7 +1,7 @@
 package example.model.concert.service
 
 import example.model.concert.ConcertId
-import example.model.concert.actor.ConcertActorProtocol._
+import example.model.concert.actor.ConcertActor._
 
 import scala.concurrent.Future
 

--- a/sample-app/src/main/scala/example/model/concert/service/DefaultBoxOfficeService.scala
+++ b/sample-app/src/main/scala/example/model/concert/service/DefaultBoxOfficeService.scala
@@ -21,7 +21,7 @@ final class DefaultBoxOfficeService(
 
   override def createConcert(id: ConcertId, numberOfTickets: Int): Future[CreateConcertResponse] = {
     val entityRef = sharding.entityRefFor(id)
-    entityRef.ask(replyTo => CreateConcertRequest(numberOfTickets, replyTo))
+    entityRef.ask(replyTo => Create(numberOfTickets, replyTo))
   }
 
   override def getConcert(id: ConcertId): Future[GetConcertResponse] = {
@@ -30,17 +30,17 @@ final class DefaultBoxOfficeService(
     // リクエストが複数回　Ask先に到達して処理される可能性があるので、冪等な処理にのみ使える。
     // TODO Use AtLeastOnceDelivery
     val entityRef = sharding.entityRefFor(id)
-    entityRef.ask(replyTo => GetConcertRequest(replyTo))
+    entityRef.ask(replyTo => Get(replyTo))
   }
 
   override def cancelConcert(id: ConcertId): Future[CancelConcertResponse] = {
     val entityRef = sharding.entityRefFor(id)
-    entityRef.ask(replyTo => CancelConcertRequest(replyTo))
+    entityRef.ask(replyTo => Cancel(replyTo))
   }
 
   override def buyConcertTickets(id: ConcertId, numberOfTickets: Int): Future[BuyConcertTicketsResponse] = {
     val entityRef = sharding.entityRefFor(id)
-    entityRef.ask(replyTo => BuyConcertTicketsRequest(numberOfTickets, replyTo))
+    entityRef.ask(replyTo => BuyTickets(numberOfTickets, replyTo))
   }
 
 }

--- a/sample-app/src/main/scala/example/model/concert/service/DefaultBoxOfficeService.scala
+++ b/sample-app/src/main/scala/example/model/concert/service/DefaultBoxOfficeService.scala
@@ -19,12 +19,12 @@ final class DefaultBoxOfficeService(
 
   private val sharding = new ConcertActorClusterSharding(system, behaviorFactory)
 
-  override def createConcert(id: ConcertId, numberOfTickets: Int): Future[CreateConcertResponse] = {
+  override def createConcert(id: ConcertId, numberOfTickets: Int): Future[CreateResponse] = {
     val entityRef = sharding.entityRefFor(id)
     entityRef.ask(replyTo => Create(numberOfTickets, replyTo))
   }
 
-  override def getConcert(id: ConcertId): Future[GetConcertResponse] = {
+  override def getConcert(id: ConcertId): Future[GetResponse] = {
     // Ask先から一定時間返答がない場合に再送処理が行われる
     // 永続化等はしていないので、Ask元がクラッシュした場合にはリクエストは失われることに注意すること
     // リクエストが複数回　Ask先に到達して処理される可能性があるので、冪等な処理にのみ使える。
@@ -33,12 +33,12 @@ final class DefaultBoxOfficeService(
     entityRef.ask(replyTo => Get(replyTo))
   }
 
-  override def cancelConcert(id: ConcertId): Future[CancelConcertResponse] = {
+  override def cancelConcert(id: ConcertId): Future[CancelResponse] = {
     val entityRef = sharding.entityRefFor(id)
     entityRef.ask(replyTo => Cancel(replyTo))
   }
 
-  override def buyConcertTickets(id: ConcertId, numberOfTickets: Int): Future[BuyConcertTicketsResponse] = {
+  override def buyConcertTickets(id: ConcertId, numberOfTickets: Int): Future[BuyTicketsResponse] = {
     val entityRef = sharding.entityRefFor(id)
     entityRef.ask(replyTo => BuyTickets(numberOfTickets, replyTo))
   }

--- a/sample-app/src/main/scala/example/model/concert/service/DefaultBoxOfficeService.scala
+++ b/sample-app/src/main/scala/example/model/concert/service/DefaultBoxOfficeService.scala
@@ -11,7 +11,7 @@ final class DefaultBoxOfficeService(
     system: ActorSystem[Nothing],
     behaviorFactory: ConcertActorBehaviorFactory,
 ) extends BoxOfficeService {
-  import example.model.concert.actor.ConcertActorProtocol._
+  import example.model.concert.actor.ConcertActor._
 
   // 設定を読み込む
   private val config                            = BoxOfficeServiceConfig(system)

--- a/sample-app/src/main/scala/example/model/concert/service/MyBoxOfficeService.scala
+++ b/sample-app/src/main/scala/example/model/concert/service/MyBoxOfficeService.scala
@@ -3,7 +3,7 @@ package example.model.concert.service
 import akka.actor.typed.ActorSystem
 import akka.util.Timeout
 import example.model.concert.ConcertId
-import example.model.concert.actor.{ ConcertActorBehaviorFactory, ConcertActorClusterSharding }
+import example.model.concert.actor.{ ConcertActor, ConcertActorBehaviorFactory, ConcertActorClusterSharding }
 
 import scala.concurrent.Future
 
@@ -14,7 +14,6 @@ final class MyBoxOfficeService(
     system: ActorSystem[Nothing],
     behaviorFactory: ConcertActorBehaviorFactory,
 ) extends BoxOfficeService {
-  import example.model.concert.actor.ConcertActor._
 
   // 設定を読み込む
   private val config                            = BoxOfficeServiceConfig(system)
@@ -22,19 +21,19 @@ final class MyBoxOfficeService(
 
   private val sharding = new ConcertActorClusterSharding(system, behaviorFactory)
 
-  override def createConcert(id: ConcertId, numberOfTickets: Int): Future[CreateResponse] = {
+  override def createConcert(id: ConcertId, numberOfTickets: Int): Future[ConcertActor.CreateResponse] = {
     ???
   }
 
-  override def getConcert(id: ConcertId): Future[GetResponse] = {
+  override def getConcert(id: ConcertId): Future[ConcertActor.GetResponse] = {
     ???
   }
 
-  override def cancelConcert(id: ConcertId): Future[CancelResponse] = {
+  override def cancelConcert(id: ConcertId): Future[ConcertActor.CancelResponse] = {
     ???
   }
 
-  override def buyConcertTickets(id: ConcertId, numberOfTickets: Int): Future[BuyTicketsResponse] = {
+  override def buyConcertTickets(id: ConcertId, numberOfTickets: Int): Future[ConcertActor.BuyTicketsResponse] = {
     ???
   }
 }

--- a/sample-app/src/main/scala/example/model/concert/service/MyBoxOfficeService.scala
+++ b/sample-app/src/main/scala/example/model/concert/service/MyBoxOfficeService.scala
@@ -14,7 +14,7 @@ final class MyBoxOfficeService(
     system: ActorSystem[Nothing],
     behaviorFactory: ConcertActorBehaviorFactory,
 ) extends BoxOfficeService {
-  import example.model.concert.actor.ConcertActorProtocol._
+  import example.model.concert.actor.ConcertActor._
 
   // 設定を読み込む
   private val config                            = BoxOfficeServiceConfig(system)

--- a/sample-app/src/main/scala/example/model/concert/service/MyBoxOfficeService.scala
+++ b/sample-app/src/main/scala/example/model/concert/service/MyBoxOfficeService.scala
@@ -22,19 +22,19 @@ final class MyBoxOfficeService(
 
   private val sharding = new ConcertActorClusterSharding(system, behaviorFactory)
 
-  override def createConcert(id: ConcertId, numberOfTickets: Int): Future[CreateConcertResponse] = {
+  override def createConcert(id: ConcertId, numberOfTickets: Int): Future[CreateResponse] = {
     ???
   }
 
-  override def getConcert(id: ConcertId): Future[GetConcertResponse] = {
+  override def getConcert(id: ConcertId): Future[GetResponse] = {
     ???
   }
 
-  override def cancelConcert(id: ConcertId): Future[CancelConcertResponse] = {
+  override def cancelConcert(id: ConcertId): Future[CancelResponse] = {
     ???
   }
 
-  override def buyConcertTickets(id: ConcertId, numberOfTickets: Int): Future[BuyConcertTicketsResponse] = {
+  override def buyConcertTickets(id: ConcertId, numberOfTickets: Int): Future[BuyTicketsResponse] = {
     ???
   }
 }

--- a/sample-app/src/main/scala/example/usecase/DefaultBoxOfficeUseCase.scala
+++ b/sample-app/src/main/scala/example/usecase/DefaultBoxOfficeUseCase.scala
@@ -1,6 +1,6 @@
 package example.usecase
 
-import example.model.concert.actor.ConcertActor._
+import example.model.concert.actor.ConcertActor
 import example.model.concert.ConcertId
 import example.model.concert.service.BoxOfficeService
 
@@ -20,9 +20,9 @@ final class DefaultBoxOfficeUseCase(
     boxOfficeService
       .createConcert(id, numberOfTickets)
       .map {
-        case succeeded: CreateSucceeded =>
+        case succeeded: ConcertActor.CreateSucceeded =>
           CreateConcertResponse(succeeded.numTickets)
-        case failed: CreateFailed =>
+        case failed: ConcertActor.CreateFailed =>
           throw new BoxOfficeUseCaseException(failed.error)
       }
   }
@@ -31,9 +31,9 @@ final class DefaultBoxOfficeUseCase(
     boxOfficeService
       .getConcert(id)
       .map {
-        case succeeded: GetSucceeded =>
+        case succeeded: ConcertActor.GetSucceeded =>
           GetConcertResponse(succeeded.tickets, succeeded.cancelled)
-        case failed: GetFailed =>
+        case failed: ConcertActor.GetFailed =>
           throw new BoxOfficeUseCaseException(failed.error)
       }
   }
@@ -42,9 +42,9 @@ final class DefaultBoxOfficeUseCase(
     boxOfficeService
       .cancelConcert(id)
       .map {
-        case succeeded: CancelSucceeded =>
+        case succeeded: ConcertActor.CancelSucceeded =>
           CancelConcertResponse(succeeded.numberOfTickets)
-        case failed: CancelFailed =>
+        case failed: ConcertActor.CancelFailed =>
           throw new BoxOfficeUseCaseException(failed.error)
       }
   }
@@ -53,9 +53,9 @@ final class DefaultBoxOfficeUseCase(
     boxOfficeService
       .buyConcertTickets(id, numberOfTickets)
       .map {
-        case succeeded: BuyTicketsSucceeded =>
+        case succeeded: ConcertActor.BuyTicketsSucceeded =>
           BuyConcertTicketsResponse(succeeded.tickets)
-        case failed: BuyTicketsFailed =>
+        case failed: ConcertActor.BuyTicketsFailed =>
           throw new BoxOfficeUseCaseException(failed.error)
       }
   }

--- a/sample-app/src/main/scala/example/usecase/DefaultBoxOfficeUseCase.scala
+++ b/sample-app/src/main/scala/example/usecase/DefaultBoxOfficeUseCase.scala
@@ -20,9 +20,9 @@ final class DefaultBoxOfficeUseCase(
     boxOfficeService
       .createConcert(id, numberOfTickets)
       .map {
-        case succeeded: CreateConcertSucceeded =>
+        case succeeded: CreateSucceeded =>
           CreateConcertResponse(succeeded.numTickets)
-        case failed: CreateConcertFailed =>
+        case failed: CreateFailed =>
           throw new BoxOfficeUseCaseException(failed.error)
       }
   }
@@ -31,9 +31,9 @@ final class DefaultBoxOfficeUseCase(
     boxOfficeService
       .getConcert(id)
       .map {
-        case succeeded: GetConcertSucceeded =>
+        case succeeded: GetSucceeded =>
           GetConcertResponse(succeeded.tickets, succeeded.cancelled)
-        case failed: GetConcertFailed =>
+        case failed: GetFailed =>
           throw new BoxOfficeUseCaseException(failed.error)
       }
   }
@@ -42,9 +42,9 @@ final class DefaultBoxOfficeUseCase(
     boxOfficeService
       .cancelConcert(id)
       .map {
-        case succeeded: CancelConcertSucceeded =>
+        case succeeded: CancelSucceeded =>
           CancelConcertResponse(succeeded.numberOfTickets)
-        case failed: CancelConcertFailed =>
+        case failed: CancelFailed =>
           throw new BoxOfficeUseCaseException(failed.error)
       }
   }
@@ -53,9 +53,9 @@ final class DefaultBoxOfficeUseCase(
     boxOfficeService
       .buyConcertTickets(id, numberOfTickets)
       .map {
-        case succeeded: BuyConcertTicketsSucceeded =>
+        case succeeded: BuyTicketsSucceeded =>
           BuyConcertTicketsResponse(succeeded.tickets)
-        case failed: BuyConcertTicketsFailed =>
+        case failed: BuyTicketsFailed =>
           throw new BoxOfficeUseCaseException(failed.error)
       }
   }

--- a/sample-app/src/main/scala/example/usecase/DefaultBoxOfficeUseCase.scala
+++ b/sample-app/src/main/scala/example/usecase/DefaultBoxOfficeUseCase.scala
@@ -1,6 +1,6 @@
 package example.usecase
 
-import example.model.concert.actor.ConcertActorProtocol._
+import example.model.concert.actor.ConcertActor._
 import example.model.concert.ConcertId
 import example.model.concert.service.BoxOfficeService
 

--- a/sample-app/src/test/scala/example/model/concert/actor/ConcertActorBehaviors.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/ConcertActorBehaviors.scala
@@ -30,9 +30,9 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
     private val underlyingFactory = new EmptyConcertActorFactory(createBehavior)
     def create(id: ConcertId, numOfTickets: Int): ActorRef[Command] = {
       val actor = underlyingFactory.create(id)
-      val probe = testKit.createTestProbe[CreateConcertResponse]()
+      val probe = testKit.createTestProbe[CreateResponse]()
       actor ! Create(numOfTickets, probe.ref)
-      probe.expectMessageType[CreateConcertSucceeded]
+      probe.expectMessageType[CreateSucceeded]
       actor
     }
   }
@@ -41,9 +41,9 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
     private val underlyingFactory = new AvailableConcertActorFactory(createBehavior)
     def create(id: ConcertId, numOfTickets: Int): ActorRef[Command] = {
       val actor = underlyingFactory.create(id, numOfTickets)
-      val probe = testKit.createTestProbe[CancelConcertResponse]()
+      val probe = testKit.createTestProbe[CancelResponse]()
       actor ! Cancel(probe.ref)
-      probe.expectMessageType[CancelConcertSucceeded]
+      probe.expectMessageType[CancelSucceeded]
       actor
     }
   }
@@ -55,9 +55,9 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val actor        = newConcertActor.create(id)
       val numOfTickets = 3
 
-      val probe = testKit.createTestProbe[CreateConcertResponse]()
+      val probe = testKit.createTestProbe[CreateResponse]()
       actor ! Create(numOfTickets, probe.ref)
-      val resp = probe.expectMessageType[CreateConcertSucceeded]
+      val resp = probe.expectMessageType[CreateSucceeded]
       resp.numTickets shouldBe numOfTickets
     }
 
@@ -65,9 +65,9 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val id    = newConcertId()
       val actor = newConcertActor.create(id)
 
-      val probe = testKit.createTestProbe[GetConcertResponse]()
+      val probe = testKit.createTestProbe[GetResponse]()
       actor ! Get(probe.ref)
-      val resp = probe.expectMessageType[GetConcertFailed]
+      val resp = probe.expectMessageType[GetFailed]
       resp.error shouldBe a[ConcertNotFoundError]
     }
 
@@ -75,9 +75,9 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val id    = newConcertId()
       val actor = newConcertActor.create(id)
 
-      val probe = testKit.createTestProbe[CancelConcertResponse]()
+      val probe = testKit.createTestProbe[CancelResponse]()
       actor ! Cancel(probe.ref)
-      val resp = probe.expectMessageType[CancelConcertFailed]
+      val resp = probe.expectMessageType[CancelFailed]
       resp.error shouldBe a[ConcertNotFoundError]
     }
 
@@ -89,9 +89,9 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val id    = newConcertId()
       val actor = newConcertActor.create(id, numOfTickets = 3)
 
-      val probe = testKit.createTestProbe[CreateConcertResponse]()
+      val probe = testKit.createTestProbe[CreateResponse]()
       actor ! Create(2, probe.ref)
-      val resp = probe.expectMessageType[CreateConcertFailed]
+      val resp = probe.expectMessageType[CreateFailed]
       resp.error shouldBe a[DuplicatedConcertError]
     }
 
@@ -99,9 +99,9 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val id    = newConcertId()
       val actor = newConcertActor.create(id, numOfTickets = 3)
 
-      val probe = testKit.createTestProbe[GetConcertResponse]()
+      val probe = testKit.createTestProbe[GetResponse]()
       actor ! Get(probe.ref)
-      val resp = probe.expectMessageType[GetConcertSucceeded]
+      val resp = probe.expectMessageType[GetSucceeded]
       resp.tickets.size shouldBe 3
     }
 
@@ -109,9 +109,9 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val id    = newConcertId()
       val actor = newConcertActor.create(id, numOfTickets = 3)
 
-      val probe = testKit.createTestProbe[CancelConcertResponse]()
+      val probe = testKit.createTestProbe[CancelResponse]()
       actor ! Cancel(probe.ref)
-      val resp = probe.expectMessageType[CancelConcertSucceeded]
+      val resp = probe.expectMessageType[CancelSucceeded]
       resp.numberOfTickets shouldBe 3
     }
 
@@ -119,9 +119,9 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val id    = newConcertId()
       val actor = newConcertActor.create(id, numOfTickets = 2)
 
-      val probe = testKit.createTestProbe[BuyConcertTicketsResponse]()
+      val probe = testKit.createTestProbe[BuyTicketsResponse]()
       actor ! BuyTickets(2, probe.ref)
-      val resp = probe.expectMessageType[BuyConcertTicketsSucceeded]
+      val resp = probe.expectMessageType[BuyTicketsSucceeded]
       resp.tickets.size shouldBe 2
     }
 
@@ -129,9 +129,9 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val id    = newConcertId()
       val actor = newConcertActor.create(id, numOfTickets = 2)
 
-      val probe = testKit.createTestProbe[BuyConcertTicketsResponse]()
+      val probe = testKit.createTestProbe[BuyTicketsResponse]()
       actor ! BuyTickets(0, probe.ref)
-      val resp = probe.expectMessageType[BuyConcertTicketsFailed]
+      val resp = probe.expectMessageType[BuyTicketsFailed]
       resp.error shouldBe a[InvalidConcertOperationError]
     }
 
@@ -139,9 +139,9 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val id    = newConcertId()
       val actor = newConcertActor.create(id, numOfTickets = 2)
 
-      val probe = testKit.createTestProbe[BuyConcertTicketsResponse]()
+      val probe = testKit.createTestProbe[BuyTicketsResponse]()
       actor ! BuyTickets(3, probe.ref)
-      val resp = probe.expectMessageType[BuyConcertTicketsFailed]
+      val resp = probe.expectMessageType[BuyTicketsFailed]
       resp.error shouldBe a[InvalidConcertOperationError]
     }
 
@@ -153,9 +153,9 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val id    = newConcertId()
       val actor = newConcertActor.create(id, numOfTickets = 2)
 
-      val probe = testKit.createTestProbe[GetConcertResponse]()
+      val probe = testKit.createTestProbe[GetResponse]()
       actor ! Get(probe.ref)
-      val resp = probe.expectMessageType[GetConcertSucceeded]
+      val resp = probe.expectMessageType[GetSucceeded]
       resp.tickets.size shouldBe 2
       resp.cancelled shouldBe true
     }
@@ -164,9 +164,9 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
       val id    = newConcertId()
       val actor = newConcertActor.create(id, numOfTickets = 1)
 
-      val probe = testKit.createTestProbe[CancelConcertResponse]()
+      val probe = testKit.createTestProbe[CancelResponse]()
       actor ! Cancel(probe.ref)
-      val resp = probe.expectMessageType[CancelConcertFailed]
+      val resp = probe.expectMessageType[CancelFailed]
       resp.error shouldBe a[InvalidConcertOperationError]
     }
 

--- a/sample-app/src/test/scala/example/model/concert/actor/ConcertActorBehaviors.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/ConcertActorBehaviors.scala
@@ -18,7 +18,7 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
   this: ActorSpecBase =>
 
   import example.model.concert._
-  import example.model.concert.actor.ConcertActorProtocol._
+  import example.model.concert.actor.ConcertActor._
 
   class EmptyConcertActorFactory(createBehavior: ConcertActorBehaviorFactory) {
     def create(id: ConcertId): ActorRef[ConcertCommandRequest] = {

--- a/sample-app/src/test/scala/example/model/concert/actor/ConcertActorClusterShardingBehaviors.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/ConcertActorClusterShardingBehaviors.scala
@@ -15,20 +15,20 @@ trait ConcertActorClusterShardingBehaviors extends ConcertIdGeneratorSupport wit
 
     "handle ConcertCommandRequests" in {
       val id        = newConcertId()
-      val probe     = testKit.createTestProbe[ConcertCommandResponse]()
+      val probe     = testKit.createTestProbe[Response]()
       val entityRef = sharding.entityRefFor(id)
 
       entityRef ! Create(2, probe.ref)
-      probe.expectMessageType[CreateConcertSucceeded]
+      probe.expectMessageType[CreateSucceeded]
 
       entityRef ! Get(probe.ref)
-      probe.expectMessageType[GetConcertSucceeded]
+      probe.expectMessageType[GetSucceeded]
 
       entityRef ! BuyTickets(1, probe.ref)
-      probe.expectMessageType[BuyConcertTicketsSucceeded]
+      probe.expectMessageType[BuyTicketsSucceeded]
 
       entityRef ! Cancel(probe.ref)
-      probe.expectMessageType[CancelConcertSucceeded]
+      probe.expectMessageType[CancelSucceeded]
     }
 
   }

--- a/sample-app/src/test/scala/example/model/concert/actor/ConcertActorClusterShardingBehaviors.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/ConcertActorClusterShardingBehaviors.scala
@@ -7,7 +7,7 @@ import example.model.concert.ConcertIdGeneratorSupport
 trait ConcertActorClusterShardingBehaviors extends ConcertIdGeneratorSupport with ClusterShardingSpecLike {
   this: ActorSpecBase =>
 
-  import example.model.concert.actor.ConcertActorProtocol._
+  import example.model.concert.actor.ConcertActor._
 
   def shardedActor(createBehavior: ConcertActorBehaviorFactory): Unit = {
 

--- a/sample-app/src/test/scala/example/model/concert/actor/ConcertActorClusterShardingBehaviors.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/ConcertActorClusterShardingBehaviors.scala
@@ -13,7 +13,7 @@ trait ConcertActorClusterShardingBehaviors extends ConcertIdGeneratorSupport wit
 
     val sharding = new ConcertActorClusterSharding(system, createBehavior)
 
-    "handle ConcertCommandRequests" in {
+    "handle ConcertActor's commands" in {
       val id        = newConcertId()
       val probe     = testKit.createTestProbe[Response]()
       val entityRef = sharding.entityRefFor(id)

--- a/sample-app/src/test/scala/example/model/concert/actor/ConcertActorClusterShardingBehaviors.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/ConcertActorClusterShardingBehaviors.scala
@@ -18,16 +18,16 @@ trait ConcertActorClusterShardingBehaviors extends ConcertIdGeneratorSupport wit
       val probe     = testKit.createTestProbe[ConcertCommandResponse]()
       val entityRef = sharding.entityRefFor(id)
 
-      entityRef ! CreateConcertRequest(2, probe.ref)
+      entityRef ! Create(2, probe.ref)
       probe.expectMessageType[CreateConcertSucceeded]
 
-      entityRef ! GetConcertRequest(probe.ref)
+      entityRef ! Get(probe.ref)
       probe.expectMessageType[GetConcertSucceeded]
 
-      entityRef ! BuyConcertTicketsRequest(1, probe.ref)
+      entityRef ! BuyTickets(1, probe.ref)
       probe.expectMessageType[BuyConcertTicketsSucceeded]
 
-      entityRef ! CancelConcertRequest(probe.ref)
+      entityRef ! Cancel(probe.ref)
       probe.expectMessageType[CancelConcertSucceeded]
     }
 

--- a/sample-app/src/test/scala/example/model/concert/service/BoxOfficeServiceBehaviors.scala
+++ b/sample-app/src/test/scala/example/model/concert/service/BoxOfficeServiceBehaviors.scala
@@ -1,5 +1,6 @@
 package example.model.concert.service
 
+import example.model.concert.actor.ConcertActor
 import example.model.concert.{ ConcertIdGenerator, ConcertTicketId }
 
 /** [[BoxOfficeService]] の 共通テスト を定義する
@@ -11,7 +12,6 @@ import example.model.concert.{ ConcertIdGenerator, ConcertTicketId }
   * を参照すること
   */
 trait BoxOfficeServiceBehaviors { this: BoxOfficeServiceSpecBase =>
-  import example.model.concert.actor.ConcertActor._
 
   val idGenerator = new ConcertIdGenerator()
 
@@ -21,39 +21,39 @@ trait BoxOfficeServiceBehaviors { this: BoxOfficeServiceSpecBase =>
       val service        = newService
       val id             = idGenerator.nextId()
       val responseFuture = service.createConcert(id, 100)
-      responseFuture.futureValue shouldBe CreateSucceeded(100)
+      responseFuture.futureValue shouldBe ConcertActor.CreateSucceeded(100)
     }
 
     "get the concert" in {
       val service              = newService
       val id                   = idGenerator.nextId()
       val createResponseFuture = service.createConcert(id, 10)
-      createResponseFuture.futureValue.isInstanceOf[CreateSucceeded] shouldBe true
+      createResponseFuture.futureValue.isInstanceOf[ConcertActor.CreateSucceeded] shouldBe true
 
       val getResponseFuture = service.getConcert(id)
       getResponseFuture.futureValue shouldBe
-      GetSucceeded((1 to 10).map(ConcertTicketId).toVector, cancelled = false)
+      ConcertActor.GetSucceeded((1 to 10).map(ConcertTicketId).toVector, cancelled = false)
     }
 
     "buy concert tickets" in {
       val service              = newService
       val id                   = idGenerator.nextId()
       val createResponseFuture = service.createConcert(id, 10)
-      createResponseFuture.futureValue.isInstanceOf[CreateSucceeded] shouldBe true
+      createResponseFuture.futureValue.isInstanceOf[ConcertActor.CreateSucceeded] shouldBe true
 
       val buyResponseFuture = service.buyConcertTickets(id, 3)
       buyResponseFuture.futureValue shouldBe
-      BuyTicketsSucceeded((1 to 3).map(ConcertTicketId).toVector)
+      ConcertActor.BuyTicketsSucceeded((1 to 3).map(ConcertTicketId).toVector)
     }
 
     "cancel the concert" in {
       val service              = newService
       val id                   = idGenerator.nextId()
       val createResponseFuture = service.createConcert(id, 10)
-      createResponseFuture.futureValue.isInstanceOf[CreateSucceeded] shouldBe true
+      createResponseFuture.futureValue.isInstanceOf[ConcertActor.CreateSucceeded] shouldBe true
 
       val cancelResponseFuture = service.cancelConcert(id)
-      cancelResponseFuture.futureValue shouldBe CancelSucceeded(10)
+      cancelResponseFuture.futureValue shouldBe ConcertActor.CancelSucceeded(10)
     }
 
   }

--- a/sample-app/src/test/scala/example/model/concert/service/BoxOfficeServiceBehaviors.scala
+++ b/sample-app/src/test/scala/example/model/concert/service/BoxOfficeServiceBehaviors.scala
@@ -21,39 +21,39 @@ trait BoxOfficeServiceBehaviors { this: BoxOfficeServiceSpecBase =>
       val service        = newService
       val id             = idGenerator.nextId()
       val responseFuture = service.createConcert(id, 100)
-      responseFuture.futureValue shouldBe CreateConcertSucceeded(100)
+      responseFuture.futureValue shouldBe CreateSucceeded(100)
     }
 
     "get the concert" in {
       val service              = newService
       val id                   = idGenerator.nextId()
       val createResponseFuture = service.createConcert(id, 10)
-      createResponseFuture.futureValue.isInstanceOf[CreateConcertSucceeded] shouldBe true
+      createResponseFuture.futureValue.isInstanceOf[CreateSucceeded] shouldBe true
 
       val getResponseFuture = service.getConcert(id)
       getResponseFuture.futureValue shouldBe
-      GetConcertSucceeded((1 to 10).map(ConcertTicketId).toVector, cancelled = false)
+      GetSucceeded((1 to 10).map(ConcertTicketId).toVector, cancelled = false)
     }
 
     "buy concert tickets" in {
       val service              = newService
       val id                   = idGenerator.nextId()
       val createResponseFuture = service.createConcert(id, 10)
-      createResponseFuture.futureValue.isInstanceOf[CreateConcertSucceeded] shouldBe true
+      createResponseFuture.futureValue.isInstanceOf[CreateSucceeded] shouldBe true
 
       val buyResponseFuture = service.buyConcertTickets(id, 3)
       buyResponseFuture.futureValue shouldBe
-      BuyConcertTicketsSucceeded((1 to 3).map(ConcertTicketId).toVector)
+      BuyTicketsSucceeded((1 to 3).map(ConcertTicketId).toVector)
     }
 
     "cancel the concert" in {
       val service              = newService
       val id                   = idGenerator.nextId()
       val createResponseFuture = service.createConcert(id, 10)
-      createResponseFuture.futureValue.isInstanceOf[CreateConcertSucceeded] shouldBe true
+      createResponseFuture.futureValue.isInstanceOf[CreateSucceeded] shouldBe true
 
       val cancelResponseFuture = service.cancelConcert(id)
-      cancelResponseFuture.futureValue shouldBe CancelConcertSucceeded(10)
+      cancelResponseFuture.futureValue shouldBe CancelSucceeded(10)
     }
 
   }

--- a/sample-app/src/test/scala/example/model/concert/service/BoxOfficeServiceBehaviors.scala
+++ b/sample-app/src/test/scala/example/model/concert/service/BoxOfficeServiceBehaviors.scala
@@ -11,7 +11,7 @@ import example.model.concert.{ ConcertIdGenerator, ConcertTicketId }
   * を参照すること
   */
 trait BoxOfficeServiceBehaviors { this: BoxOfficeServiceSpecBase =>
-  import example.model.concert.actor.ConcertActorProtocol._
+  import example.model.concert.actor.ConcertActor._
 
   val idGenerator = new ConcertIdGenerator()
 


### PR DESCRIPTION
## 方針
- `ConcertActorProtocol` を `ConcertActor` に改名します
  `ConcertActor` に `Command`、`Response`、`Behavior[Command]` を定義することが一般的かと思われます。
  演習やテスト共通化のため、`DefaultConcertActor` や `MyConcertActor` などの `ConcertActor` 派生があります。
  これらの派生がない場合は、`ConcertActor` というアクターが1つある形になるため、
  本来の慣習になるべく沿う形にしておきたいと考えています。 
-  コマンドとレスポンスが簡潔な名前になるように改名します
- `ConcertActor` の振る舞いを定義する `DefaultConcertActor` 等以外では、
  `ConcertActor`修飾付きでコマンド名やレスポンス名を扱うようにします。
  `ConcertActor.Command` などのように参照するようになり、より読みやすくになると思われます。

## 対応していないこと
恐らく `ConcertActor.Response` をいろいろな場所で使用するのはよくなさそうです。
`BoxOfficeService` が専用のレスポンス型を提供するようにしたいと考えています。