### PR TITLE
Akka 2.6.14 に更新する

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val akka     = "2.6.8"
+    val akka     = "2.6.14"
     val akkaHttp = "10.1.12"
     // Scalactic, ScalaTest のバージョンは念のため同一にする
     val scalactic                = "3.2.2"

--- a/sample-app/src/main/resources/akka.conf
+++ b/sample-app/src/main/resources/akka.conf
@@ -1,4 +1,7 @@
 akka {
+  # 動作確認&演習用に DEBUG にする
+  loglevel = DEBUG
+
   actor {
     # デバッグ用
     # 本番ではオフにすること

--- a/sample-app/src/main/resources/logback.xml
+++ b/sample-app/src/main/resources/logback.xml
@@ -9,8 +9,12 @@
     <!-- 演習を通して EventSourcedBehavior のログを確認したいため -->
     <logger name="akka.persistence.typed" level="debug" />
 
+    <!-- アプリケーションのログは詳細に出したいため -->
     <logger name="example" level="debug"/>
+
+    <!-- すべてを DEBUG にすると煩雑だったため -->
     <root level="info">
         <appender-ref ref="STDOUT"/>
     </root>
+
 </configuration>

--- a/sample-app/src/main/resources/logback.xml
+++ b/sample-app/src/main/resources/logback.xml
@@ -5,6 +5,10 @@
             <pattern>[%-4level] [%d{MM/dd/yyyy HH:mm:ss.SSS}] [%thread] [%logger{36}] %msg%n</pattern>
         </encoder>
     </appender>
+
+    <!-- 演習を通して EventSourcedBehavior のログを確認したいため -->
+    <logger name="akka.persistence.typed" level="debug" />
+
     <logger name="example" level="debug"/>
     <root level="info">
         <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
Akka 最新版に更新します。
RMU を akka-projection で再実装することも踏まえ、`2.6.10` 以上まで更新したいと思っています。

[Akka version Overview • Akka Projection](https://doc.akka.io/docs/akka-projection/current/overview.html#akka-version)
> Akka Projections requires Akka 2.6.10 or later. See Akka’s Binary Compatibility Rules for details.

## Release Notes (2.6.9 ~ 2.6.14)
- [Akka 2.6.9 Released | Akka](https://akka.io/blog/news/2020/09/09/akka-2.6.9-released)
- [Akka 2.6.10 Released | Akka](https://akka.io/blog/news/2020/10/09/akka-2.6.10-released)
- [Akka 2.6.11 Released | Akka](https://akka.io/blog/news/2021/01/15/akka-2.6.11-released)
- [Akka 2.6.13 Released | Akka](https://akka.io/blog/news/2021/02/23/akka-2.6.13-released)
- [Akka 2.6.14 Released | Akka](https://akka.io/blog/news/2021/04/08/akka-2.6.14-released)

## 特筆すべき変更点

- Akka 2.6.13 にて `EventSourcedBehavior` の logger が分離されました
  ~~[akka.actor.testkit.typed.timefactor unexpected behavior · Issue #30021 · akka/akka](https://github.com/akka/akka/issues/30021)~~
  [EventSourcedBehavior logging on behalf of users · Issue #30005 · akka/akka](https://github.com/akka/akka/issues/30005)
  演習にてログを確認したい箇所があるため、ログ出力の設定を変更しました。