### PR TITLE
Akka HTTP 10.2.4 に更新する

### DIFF
--- a/exercise-akka-http-basic/src/main/scala/answer/Answer1.scala
+++ b/exercise-akka-http-basic/src/main/scala/answer/Answer1.scala
@@ -1,6 +1,7 @@
 package answer
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
@@ -8,7 +9,7 @@ import akka.http.scaladsl.server.Route
 // curl --silent --noproxy '*' localhost:8080/my/hello
 // curl --silent --noproxy '*' localhost:8080/my/question
 object Answer1 extends App {
-  private implicit val system = ActorSystem("answer1")
+  private implicit val system = ActorSystem(Behaviors.empty, "answer1")
 
   private val route: Route = concat(
     path("my" / "hello") {

--- a/exercise-akka-http-basic/src/main/scala/answer/Answer1.scala
+++ b/exercise-akka-http-basic/src/main/scala/answer/Answer1.scala
@@ -8,8 +8,7 @@ import akka.http.scaladsl.server.Route
 // curl --silent --noproxy '*' localhost:8080/my/hello
 // curl --silent --noproxy '*' localhost:8080/my/question
 object Answer1 extends App {
-  private implicit val system           = ActorSystem("answer1")
-  private implicit val executionContext = system.dispatcher
+  private implicit val system = ActorSystem("answer1")
 
   private val route: Route = concat(
     path("my" / "hello") {

--- a/exercise-akka-http-basic/src/main/scala/answer/Answer1.scala
+++ b/exercise-akka-http-basic/src/main/scala/answer/Answer1.scala
@@ -23,5 +23,5 @@ object Answer1 extends App {
       }
     },
   )
-  Http().bindAndHandle(route, "localhost", 8080)
+  Http().newServerAt("localhost", 8080).bind(route)
 }

--- a/exercise-akka-http-basic/src/main/scala/answer/Answer2A.scala
+++ b/exercise-akka-http-basic/src/main/scala/answer/Answer2A.scala
@@ -16,5 +16,5 @@ object Answer2A extends App {
         complete((value * 2).toString)
       }
     }
-  Http().bindAndHandle(route, "localhost", 8080)
+  Http().newServerAt("localhost", 8080).bind(route)
 }

--- a/exercise-akka-http-basic/src/main/scala/answer/Answer2A.scala
+++ b/exercise-akka-http-basic/src/main/scala/answer/Answer2A.scala
@@ -1,13 +1,14 @@
 package answer
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 
 // curl --silent --noproxy '*' localhost:8080/path-example/1234
 object Answer2A extends App {
-  private implicit val system = ActorSystem("answer2a")
+  private implicit val system = ActorSystem(Behaviors.empty, "answer2a")
 
   private val route: Route =
     path("path-example" / IntNumber) { value: Int =>

--- a/exercise-akka-http-basic/src/main/scala/answer/Answer2A.scala
+++ b/exercise-akka-http-basic/src/main/scala/answer/Answer2A.scala
@@ -7,8 +7,7 @@ import akka.http.scaladsl.server.Route
 
 // curl --silent --noproxy '*' localhost:8080/path-example/1234
 object Answer2A extends App {
-  private implicit val system           = ActorSystem("answer2a")
-  private implicit val executionContext = system.dispatcher
+  private implicit val system = ActorSystem("answer2a")
 
   private val route: Route =
     path("path-example" / IntNumber) { value: Int =>

--- a/exercise-akka-http-basic/src/main/scala/answer/Answer2B.scala
+++ b/exercise-akka-http-basic/src/main/scala/answer/Answer2B.scala
@@ -27,5 +27,5 @@ object Answer2B extends App {
         }
       }
     }
-  Http().bindAndHandle(route, "localhost", 8080)
+  Http().newServerAt("localhost", 8080).bind(route)
 }

--- a/exercise-akka-http-basic/src/main/scala/answer/Answer2B.scala
+++ b/exercise-akka-http-basic/src/main/scala/answer/Answer2B.scala
@@ -1,6 +1,7 @@
 package answer
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
@@ -9,7 +10,7 @@ import spray.json.DefaultJsonProtocol._
 
 // curl --silent --noproxy '*' -X POST  -H "Content-Type:application/json" -d '{"value":123}' localhost:8080/body-example
 object Answer2B extends App {
-  private implicit val system = ActorSystem("answer2b")
+  private implicit val system = ActorSystem(Behaviors.empty, "answer2b")
 
   private case class MyRequestBody(value: Int)
   private case class MyResponseBody(message: String, value: Int)

--- a/exercise-akka-http-basic/src/main/scala/answer/Answer2B.scala
+++ b/exercise-akka-http-basic/src/main/scala/answer/Answer2B.scala
@@ -9,8 +9,7 @@ import spray.json.DefaultJsonProtocol._
 
 // curl --silent --noproxy '*' -X POST  -H "Content-Type:application/json" -d '{"value":123}' localhost:8080/body-example
 object Answer2B extends App {
-  private implicit val system           = ActorSystem("answer2b")
-  private implicit val executionContext = system.dispatcher
+  private implicit val system = ActorSystem("answer2b")
 
   private case class MyRequestBody(value: Int)
   private case class MyResponseBody(message: String, value: Int)

--- a/exercise-akka-http-basic/src/main/scala/answer/Answer2C.scala
+++ b/exercise-akka-http-basic/src/main/scala/answer/Answer2C.scala
@@ -19,5 +19,5 @@ object Answer2C extends App {
       }
     }
   }
-  Http().bindAndHandle(route, "localhost", 8080)
+  Http().newServerAt("localhost", 8080).bind(route)
 }

--- a/exercise-akka-http-basic/src/main/scala/answer/Answer2C.scala
+++ b/exercise-akka-http-basic/src/main/scala/answer/Answer2C.scala
@@ -1,13 +1,14 @@
 package answer
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 
 // curl --silent --noproxy '*' "localhost:8080/query-example?p=12"
 object Answer2C extends App {
-  private implicit val system = ActorSystem("entity-example")
+  private implicit val system = ActorSystem(Behaviors.empty, "entity-example")
 
   private val route: Route = {
     path("query-example") {

--- a/exercise-akka-http-basic/src/main/scala/answer/Answer2C.scala
+++ b/exercise-akka-http-basic/src/main/scala/answer/Answer2C.scala
@@ -7,8 +7,7 @@ import akka.http.scaladsl.server.Route
 
 // curl --silent --noproxy '*' "localhost:8080/query-example?p=12"
 object Answer2C extends App {
-  private implicit val system           = ActorSystem("entity-example")
-  private implicit val executionContext = system.dispatcher
+  private implicit val system = ActorSystem("entity-example")
 
   private val route: Route = {
     path("query-example") {

--- a/exercise-akka-http-basic/src/main/scala/example/BasicExample.scala
+++ b/exercise-akka-http-basic/src/main/scala/example/BasicExample.scala
@@ -7,8 +7,7 @@ import akka.http.scaladsl.server.Route
 
 // curl --silent --noproxy '*' localhost:8080/hello
 object BasicExample extends App {
-  private implicit val system           = ActorSystem("basic-example")
-  private implicit val executionContext = system.dispatcher
+  private implicit val system = ActorSystem("basic-example")
 
   private val route: Route =
     path("hello") {

--- a/exercise-akka-http-basic/src/main/scala/example/BasicExample.scala
+++ b/exercise-akka-http-basic/src/main/scala/example/BasicExample.scala
@@ -16,5 +16,5 @@ object BasicExample extends App {
         complete("world")
       }
     }
-  Http().bindAndHandle(route, "localhost", 8080)
+  Http().newServerAt("localhost", 8080).bind(route)
 }

--- a/exercise-akka-http-basic/src/main/scala/example/BasicExample.scala
+++ b/exercise-akka-http-basic/src/main/scala/example/BasicExample.scala
@@ -1,13 +1,14 @@
 package example
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 
 // curl --silent --noproxy '*' localhost:8080/hello
 object BasicExample extends App {
-  private implicit val system = ActorSystem("basic-example")
+  private implicit val system = ActorSystem(Behaviors.empty, "basic-example")
 
   private val route: Route =
     path("hello") {

--- a/exercise-akka-http-basic/src/main/scala/example/EntityExample.scala
+++ b/exercise-akka-http-basic/src/main/scala/example/EntityExample.scala
@@ -29,5 +29,5 @@ object EntityExample extends App {
       }
     }
   }
-  Http().bindAndHandle(route, "localhost", 8080)
+  Http().newServerAt("localhost", 8080).bind(route)
 }

--- a/exercise-akka-http-basic/src/main/scala/example/EntityExample.scala
+++ b/exercise-akka-http-basic/src/main/scala/example/EntityExample.scala
@@ -1,6 +1,7 @@
 package example
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.server.Directives._
@@ -9,7 +10,7 @@ import spray.json.DefaultJsonProtocol._
 
 // curl --silent --noproxy '*' -X POST  -H "Content-Type:application/json" -d '{"value":123}' localhost:8080/example/entity
 object EntityExample extends App {
-  private implicit val system = ActorSystem("entity-example")
+  private implicit val system = ActorSystem(Behaviors.empty, "entity-example")
 
   private val route: Route = {
     // リクエストボディを取り出すためのケースクラス

--- a/exercise-akka-http-basic/src/main/scala/example/EntityExample.scala
+++ b/exercise-akka-http-basic/src/main/scala/example/EntityExample.scala
@@ -9,8 +9,7 @@ import spray.json.DefaultJsonProtocol._
 
 // curl --silent --noproxy '*' -X POST  -H "Content-Type:application/json" -d '{"value":123}' localhost:8080/example/entity
 object EntityExample extends App {
-  private implicit val system           = ActorSystem("entity-example")
-  private implicit val executionContext = system.dispatcher
+  private implicit val system = ActorSystem("entity-example")
 
   private val route: Route = {
     // リクエストボディを取り出すためのケースクラス

--- a/exercise-akka-http-basic/src/main/scala/example/PathExample.scala
+++ b/exercise-akka-http-basic/src/main/scala/example/PathExample.scala
@@ -7,8 +7,7 @@ import akka.http.scaladsl.server.Route
 
 // curl --silent --noproxy '*' localhost:8080/example/hello
 object PathExample extends App {
-  private implicit val system           = ActorSystem("path-example")
-  private implicit val executionContext = system.dispatcher
+  private implicit val system = ActorSystem("path-example")
 
   private val route: Route =
     path("example" / "hello") {

--- a/exercise-akka-http-basic/src/main/scala/example/PathExample.scala
+++ b/exercise-akka-http-basic/src/main/scala/example/PathExample.scala
@@ -1,13 +1,14 @@
 package example
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 
 // curl --silent --noproxy '*' localhost:8080/example/hello
 object PathExample extends App {
-  private implicit val system = ActorSystem("path-example")
+  private implicit val system = ActorSystem(Behaviors.empty, "path-example")
 
   private val route: Route =
     path("example" / "hello") {

--- a/exercise-akka-http-basic/src/main/scala/example/PathExample.scala
+++ b/exercise-akka-http-basic/src/main/scala/example/PathExample.scala
@@ -16,5 +16,5 @@ object PathExample extends App {
         complete("example_world")
       }
     }
-  Http().bindAndHandle(route, "localhost", 8080)
+  Http().newServerAt("localhost", 8080).bind(route)
 }

--- a/exercise-akka-http-basic/src/main/scala/example/PathMatcherExample.scala
+++ b/exercise-akka-http-basic/src/main/scala/example/PathMatcherExample.scala
@@ -1,6 +1,7 @@
 package example
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
@@ -8,7 +9,7 @@ import akka.http.scaladsl.server.Route
 
 // curl --silent --noproxy '*' localhost:8080/example/123
 object PathMatcherExample extends App {
-  private implicit val system = ActorSystem("path-matcher-example")
+  private implicit val system = ActorSystem(Behaviors.empty, "path-matcher-example")
 
   private val route: Route =
     // /example/{IntNumber} のパスを定義する。

--- a/exercise-akka-http-basic/src/main/scala/example/PathMatcherExample.scala
+++ b/exercise-akka-http-basic/src/main/scala/example/PathMatcherExample.scala
@@ -8,8 +8,7 @@ import akka.http.scaladsl.server.Route
 
 // curl --silent --noproxy '*' localhost:8080/example/123
 object PathMatcherExample extends App {
-  private implicit val system           = ActorSystem("path-matcher-example")
-  private implicit val executionContext = system.dispatcher
+  private implicit val system = ActorSystem("path-matcher-example")
 
   private val route: Route =
     // /example/{IntNumber} のパスを定義する。

--- a/exercise-akka-http-basic/src/main/scala/example/PathMatcherExample.scala
+++ b/exercise-akka-http-basic/src/main/scala/example/PathMatcherExample.scala
@@ -21,5 +21,5 @@ object PathMatcherExample extends App {
         complete(response.toString)
       }
     }
-  Http().bindAndHandle(route, "localhost", 8080)
+  Http().newServerAt("localhost", 8080).bind(route)
 }

--- a/exercise-akka-http-basic/src/main/scala/example/QueryParameterExample.scala
+++ b/exercise-akka-http-basic/src/main/scala/example/QueryParameterExample.scala
@@ -10,8 +10,7 @@ import spray.json._
 
 // curl --silent --noproxy '*' "localhost:8080/example/query?s=hello&page=3"
 object QueryParameterExample extends App {
-  private implicit val system           = ActorSystem("query-parameter-example")
-  private implicit val executionContext = system.dispatcher
+  private implicit val system = ActorSystem("query-parameter-example")
 
   private val route: Route = {
     // /example/query?s=hi&page=10

--- a/exercise-akka-http-basic/src/main/scala/example/QueryParameterExample.scala
+++ b/exercise-akka-http-basic/src/main/scala/example/QueryParameterExample.scala
@@ -1,6 +1,7 @@
 package example
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.server.Directives._
@@ -10,7 +11,7 @@ import spray.json._
 
 // curl --silent --noproxy '*' "localhost:8080/example/query?s=hello&page=3"
 object QueryParameterExample extends App {
-  private implicit val system = ActorSystem("query-parameter-example")
+  private implicit val system = ActorSystem(Behaviors.empty, "query-parameter-example")
 
   private val route: Route = {
     // /example/query?s=hi&page=10

--- a/exercise-akka-http-basic/src/main/scala/example/QueryParameterExample.scala
+++ b/exercise-akka-http-basic/src/main/scala/example/QueryParameterExample.scala
@@ -19,11 +19,11 @@ object QueryParameterExample extends App {
     // JSON で返す。
     path("example" / "query") {
       get {
-        parameters(("s", "page".as[Int] ? 0)) { (searchString, page) =>
+        parameters("s", "page".as[Int] ? 0) { (searchString, page) =>
           complete((searchString, page).toJson)
         }
       }
     }
   }
-  Http().bindAndHandle(route, "localhost", 8080)
+  Http().newServerAt("localhost", 8080).bind(route)
 }

--- a/exercise-akka-http-basic/src/main/scala/exercise/Exercise1.scala
+++ b/exercise-akka-http-basic/src/main/scala/exercise/Exercise1.scala
@@ -19,8 +19,7 @@ import akka.http.scaladsl.server.Route
    curl --silent --noproxy '*' localhost:8080/my/question
  */
 object Exercise1 extends App {
-  private implicit val system           = ActorSystem("exercise1")
-  private implicit val executionContext = system.dispatcher
+  private implicit val system = ActorSystem("exercise1")
 
   private val route: Route = {
     ???

--- a/exercise-akka-http-basic/src/main/scala/exercise/Exercise1.scala
+++ b/exercise-akka-http-basic/src/main/scala/exercise/Exercise1.scala
@@ -25,5 +25,5 @@ object Exercise1 extends App {
   private val route: Route = {
     ???
   }
-  Http().bindAndHandle(route, "localhost", 8080)
+  Http().newServerAt("localhost", 8080).bind(route)
 }

--- a/exercise-akka-http-basic/src/main/scala/exercise/Exercise1.scala
+++ b/exercise-akka-http-basic/src/main/scala/exercise/Exercise1.scala
@@ -1,6 +1,7 @@
 package exercise
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
@@ -19,7 +20,7 @@ import akka.http.scaladsl.server.Route
    curl --silent --noproxy '*' localhost:8080/my/question
  */
 object Exercise1 extends App {
-  private implicit val system = ActorSystem("exercise1")
+  private implicit val system = ActorSystem(Behaviors.empty, "exercise1")
 
   private val route: Route = {
     ???

--- a/exercise-akka-http-basic/src/main/scala/exercise/Exercise2A.scala
+++ b/exercise-akka-http-basic/src/main/scala/exercise/Exercise2A.scala
@@ -19,6 +19,6 @@ object Exercise2A extends App {
   private val route: Route = {
     ???
   }
-  Http().bindAndHandle(route, "localhost", 8080)
+  Http().newServerAt("localhost", 8080).bind(route)
 
 }

--- a/exercise-akka-http-basic/src/main/scala/exercise/Exercise2A.scala
+++ b/exercise-akka-http-basic/src/main/scala/exercise/Exercise2A.scala
@@ -13,8 +13,7 @@ import akka.http.scaladsl.server.Route
   - curl --silent --noproxy '*' localhost:8080/path-example/1234
  */
 object Exercise2A extends App {
-  private implicit val system           = ActorSystem("exercise2a")
-  private implicit val executionContext = system.dispatcher
+  private implicit val system = ActorSystem("exercise2a")
 
   private val route: Route = {
     ???

--- a/exercise-akka-http-basic/src/main/scala/exercise/Exercise2A.scala
+++ b/exercise-akka-http-basic/src/main/scala/exercise/Exercise2A.scala
@@ -1,6 +1,7 @@
 package exercise
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl._
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
@@ -13,7 +14,7 @@ import akka.http.scaladsl.server.Route
   - curl --silent --noproxy '*' localhost:8080/path-example/1234
  */
 object Exercise2A extends App {
-  private implicit val system = ActorSystem("exercise2a")
+  private implicit val system = ActorSystem(Behaviors.empty, "exercise2a")
 
   private val route: Route = {
     ???

--- a/exercise-akka-http-basic/src/main/scala/exercise/Exercise2B.scala
+++ b/exercise-akka-http-basic/src/main/scala/exercise/Exercise2B.scala
@@ -18,8 +18,7 @@ import spray.json.DefaultJsonProtocol._
   curl --silent --noproxy '*' -X POST  -H "Content-Type:application/json" -d '{"value":123}' localhost:8080/body-example
  */
 object Exercise2B extends App {
-  private implicit val system           = ActorSystem("answer2b")
-  private implicit val executionContext = system.dispatcher
+  private implicit val system = ActorSystem("answer2b")
 
   // リクエストとレスポンスの型
   private case class MyRequestBody(value: Int)

--- a/exercise-akka-http-basic/src/main/scala/exercise/Exercise2B.scala
+++ b/exercise-akka-http-basic/src/main/scala/exercise/Exercise2B.scala
@@ -33,5 +33,5 @@ object Exercise2B extends App {
   private val route: Route = {
     ???
   }
-  Http().bindAndHandle(route, "localhost", 8080)
+  Http().newServerAt("localhost", 8080).bind(route)
 }

--- a/exercise-akka-http-basic/src/main/scala/exercise/Exercise2B.scala
+++ b/exercise-akka-http-basic/src/main/scala/exercise/Exercise2B.scala
@@ -1,6 +1,7 @@
 package exercise
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
@@ -18,7 +19,7 @@ import spray.json.DefaultJsonProtocol._
   curl --silent --noproxy '*' -X POST  -H "Content-Type:application/json" -d '{"value":123}' localhost:8080/body-example
  */
 object Exercise2B extends App {
-  private implicit val system = ActorSystem("answer2b")
+  private implicit val system = ActorSystem(Behaviors.empty, "answer2b")
 
   // リクエストとレスポンスの型
   private case class MyRequestBody(value: Int)

--- a/exercise-akka-http-basic/src/main/scala/exercise/Exercise2C.scala
+++ b/exercise-akka-http-basic/src/main/scala/exercise/Exercise2C.scala
@@ -19,5 +19,5 @@ object Exercise2C extends App {
   private val route: Route = {
     ???
   }
-  Http().bindAndHandle(route, "localhost", 8080)
+  Http().newServerAt("localhost", 8080).bind(route)
 }

--- a/exercise-akka-http-basic/src/main/scala/exercise/Exercise2C.scala
+++ b/exercise-akka-http-basic/src/main/scala/exercise/Exercise2C.scala
@@ -1,6 +1,7 @@
 package exercise
 
-import akka.actor.ActorSystem
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
@@ -13,7 +14,7 @@ import spray.json.DefaultJsonProtocol._
   curl --silent --noproxy '*' "localhost:8080/query-example?p=12"
  */
 object Exercise2C extends App {
-  private implicit val system = ActorSystem("entity-example")
+  private implicit val system = ActorSystem(Behaviors.empty, "entity-example")
 
   private val route: Route = {
     ???

--- a/exercise-akka-http-basic/src/main/scala/exercise/Exercise2C.scala
+++ b/exercise-akka-http-basic/src/main/scala/exercise/Exercise2C.scala
@@ -13,8 +13,7 @@ import spray.json.DefaultJsonProtocol._
   curl --silent --noproxy '*' "localhost:8080/query-example?p=12"
  */
 object Exercise2C extends App {
-  private implicit val system           = ActorSystem("entity-example")
-  private implicit val executionContext = system.dispatcher
+  private implicit val system = ActorSystem("entity-example")
 
   private val route: Route = {
     ???

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   object Versions {
     val akka     = "2.6.8"
-    val akkaHttp = "10.1.12"
+    val akkaHttp = "10.2.4"
     // Scalactic, ScalaTest のバージョンは念のため同一にする
     val scalactic                = "3.2.2"
     val scalaTest                = "3.2.2"

--- a/sample-app/src/main/scala/example/application/http/MainHttpApiServer.scala
+++ b/sample-app/src/main/scala/example/application/http/MainHttpApiServer.scala
@@ -1,7 +1,6 @@
 package example.application.http
 
 import akka.Done
-import akka.{ actor => classic }
 import akka.actor.CoordinatedShutdown
 import akka.actor.typed.ActorSystem
 import akka.http.scaladsl.Http
@@ -13,10 +12,10 @@ import scala.concurrent._
 final class MainHttpApiServer(
     config: MainHttpApiServerConfig,
     resource: MainHttpApiServerResource,
+)(implicit
     system: ActorSystem[Nothing],
 ) {
   import system.executionContext
-  private implicit val classicSystem: classic.ActorSystem = system.classicSystem
 
   private val log = LoggerFactory.getLogger(this.getClass)
 

--- a/sample-app/src/main/scala/example/application/http/MainHttpApiServer.scala
+++ b/sample-app/src/main/scala/example/application/http/MainHttpApiServer.scala
@@ -23,7 +23,8 @@ final class MainHttpApiServer(
   def start(): Future[Done] = {
     // HTTPサーバーの起動
     Http()
-      .bindAndHandle(resource.routes, config.host, config.port)
+      .newServerAt(config.host, config.port)
+      .bind(resource.routes)
       .map(onBindSuccess)
       .map(_ => Done)
   }


### PR DESCRIPTION
Akka HTTP 10.2.4 に更新します。

## Release Notes
[10.2.x Release Notes • Akka HTTP](https://doc.akka.io/docs/akka-http/current/release-notes/10.2.x.html)

## 特筆すべき変更点

- サーバを起動するAPIが変更されました
  [Seamless integration with Akka 2.6 and new server API entrypoints - 10.2.x Release Notes • Akka HTTP](https://doc.akka.io/docs/akka-http/current/release-notes/10.2.x.html#seamless-integration-with-akka-2-6-and-new-server-api-entrypoints)
- 同じソースコードで Typed ActorSystem も利用できるようになりました
  [10.2.x Release Notes • Akka HTTP](https://doc.akka.io/docs/akka-http/current/release-notes/10.2.x.html#10-2-0#:~:text=Http%20APIs%20now%20work%20the%20same%20whether%20a%20classic%20or%20a%20typed%20ActorSystem%20is%20provided)