### PR TITLE
ConcertActorBehaviors のリファクタ

### DIFF
--- a/sample-app/src/test/scala/example/model/concert/actor/DefaultConcertActorSpec.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/DefaultConcertActorSpec.scala
@@ -10,9 +10,9 @@ final class DefaultConcertActorSpec
   private def createBehavior: ConcertActorBehaviorFactory = DefaultConcertActor
 
   "DefaultConcertActor" should {
-    behave like emptyConcertActor(new EmptyConcertActorFactory(createBehavior))
-    behave like availableConcertActor(new AvailableConcertActorFactory(createBehavior))
-    behave like cancelledConcertActor(new CancelledConcertActorFactory(createBehavior))
+    behave like emptyConcertActor(createBehavior)
+    behave like availableConcertActor(createBehavior)
+    behave like cancelledConcertActor(createBehavior)
     behave like shardedActor(createBehavior)
   }
 

--- a/sample-app/src/test/scala/example/model/concert/actor/DefaultConcertActorWithEventPersistenceSpec.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/DefaultConcertActorWithEventPersistenceSpec.scala
@@ -10,9 +10,9 @@ final class DefaultConcertActorWithEventPersistenceSpec
   private def createBehavior: ConcertActorBehaviorFactory = DefaultConcertActorWithEventPersistence
 
   "DefaultConcertActorWithEventPersistence" should {
-    behave like emptyConcertActor(new EmptyConcertActorFactory(createBehavior))
-    behave like availableConcertActor(new AvailableConcertActorFactory(createBehavior))
-    behave like cancelledConcertActor(new CancelledConcertActorFactory(createBehavior))
+    behave like emptyConcertActor(createBehavior)
+    behave like availableConcertActor(createBehavior)
+    behave like cancelledConcertActor(createBehavior)
     behave like shardedActor(createBehavior)
   }
 

--- a/sample-app/src/test/scala/example/model/concert/actor/MyConcertActorSpec.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/MyConcertActorSpec.scala
@@ -12,9 +12,9 @@ final class MyConcertActorSpec
   private def createBehavior: ConcertActorBehaviorFactory = MyConcertActor
 
   "MyConcertActor" should {
-    behave like emptyConcertActor(new EmptyConcertActorFactory(createBehavior))
-    behave like availableConcertActor(new AvailableConcertActorFactory(createBehavior))
-    behave like cancelledConcertActor(new CancelledConcertActorFactory(createBehavior))
+    behave like emptyConcertActor(createBehavior)
+    behave like availableConcertActor(createBehavior)
+    behave like cancelledConcertActor(createBehavior)
     behave like shardedActor(createBehavior)
   }
 


### PR DESCRIPTION
Helper として使っている 3つの Factory (`EmptyConcertActorFactory`, `AvailableConcertActorFactory`, `CancelledConcertActorFactory`) を `ConcertActorBehaviors` の内部に隠蔽します。