### PR TITLE
ConcertActor の永続化をテストする

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,6 +103,7 @@ lazy val SampleApp = (project in file("sample-app"))
       Dependencies.Akka.cluster,
       Dependencies.Akka.clusterSharding,
       Dependencies.Akka.persistence,
+      Dependencies.Akka.persistenceTestKit % Test,
       Dependencies.Akka.persistenceQuery,
       Dependencies.Akka.stream,
       Dependencies.Akka.streamTestKit % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,14 +17,15 @@ object Dependencies {
   }
 
   object Akka {
-    val actor            = "com.typesafe.akka" %% "akka-actor-typed"            % Versions.akka
-    val actorTestKit     = "com.typesafe.akka" %% "akka-actor-testkit-typed"    % Versions.akka
-    val cluster          = "com.typesafe.akka" %% "akka-cluster-typed"          % Versions.akka
-    val clusterSharding  = "com.typesafe.akka" %% "akka-cluster-sharding-typed" % Versions.akka
-    val persistence      = "com.typesafe.akka" %% "akka-persistence-typed"      % Versions.akka
-    val persistenceQuery = "com.typesafe.akka" %% "akka-persistence-query"      % Versions.akka
-    val stream           = "com.typesafe.akka" %% "akka-stream-typed"           % Versions.akka
-    val streamTestKit    = "com.typesafe.akka" %% "akka-stream-testkit"         % Versions.akka
+    val actor              = "com.typesafe.akka" %% "akka-actor-typed"            % Versions.akka
+    val actorTestKit       = "com.typesafe.akka" %% "akka-actor-testkit-typed"    % Versions.akka
+    val cluster            = "com.typesafe.akka" %% "akka-cluster-typed"          % Versions.akka
+    val clusterSharding    = "com.typesafe.akka" %% "akka-cluster-sharding-typed" % Versions.akka
+    val persistence        = "com.typesafe.akka" %% "akka-persistence-typed"      % Versions.akka
+    val persistenceTestKit = "com.typesafe.akka" %% "akka-persistence-testkit"    % Versions.akka
+    val persistenceQuery   = "com.typesafe.akka" %% "akka-persistence-query"      % Versions.akka
+    val stream             = "com.typesafe.akka" %% "akka-stream-typed"           % Versions.akka
+    val streamTestKit      = "com.typesafe.akka" %% "akka-stream-testkit"         % Versions.akka
   }
 
   object AkkaHttp {

--- a/sample-app/src/test/resources/application.conf
+++ b/sample-app/src/test/resources/application.conf
@@ -16,3 +16,7 @@ akka.persistence {
   journal.plugin = "akka.persistence.journal.inmem"
   snapshot-store.plugin = "akka.persistence.no-snapshot-store"
 }
+
+akka.persistence.testkit {
+  events.assert-timeout = 1s
+}

--- a/sample-app/src/test/resources/application.conf
+++ b/sample-app/src/test/resources/application.conf
@@ -19,4 +19,5 @@ akka.persistence {
 
 akka.persistence.testkit {
   events.assert-timeout = 1s
+  snapshots.assert-timeout = 1s
 }

--- a/sample-app/src/test/scala/example/ActorSpecBase.scala
+++ b/sample-app/src/test/scala/example/ActorSpecBase.scala
@@ -1,7 +1,7 @@
 package example
 
 import akka.actor.testkit.typed.scaladsl.{ ActorTestKit, ScalaTestWithActorTestKit }
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -27,6 +27,10 @@ abstract class ActorSpecBase(testKit: ActorTestKit)
     // デフォルトの振る舞いでは `application-test` もしくは `reference` のみが読み込まれる。
     // テスト全般にわたって `application` と `reference` を使用したいため、ConfigFactory#load を使用する。
     this(ActorTestKit(ConfigFactory.load()))
+  }
+
+  def this(customConfig: Config) = {
+    this(ActorTestKit(customConfig))
   }
 
 }

--- a/sample-app/src/test/scala/example/model/concert/actor/ConcertActorBehaviors.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/ConcertActorBehaviors.scala
@@ -1,10 +1,11 @@
 package example.model.concert.actor
 
 import akka.actor.typed.ActorRef
+import akka.persistence.testkit.scaladsl.PersistenceTestKit
 import akka.persistence.typed.PersistenceId
 import example.ActorSpecBase
-import example.model.concert.ConcertError._
 import example.model.concert.ConcertIdGeneratorSupport
+import org.scalatest.BeforeAndAfterEach
 
 /** ConcertActor の 共通テスト を定義する
   *
@@ -14,36 +15,47 @@ import example.model.concert.ConcertIdGeneratorSupport
   * [[https://www.scalatest.org/user_guide/sharing_tests Sharing tests]]
   * を参照すること
   */
-trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
+trait ConcertActorBehaviors extends BeforeAndAfterEach with ConcertIdGeneratorSupport {
   this: ActorSpecBase =>
 
+  import example.model.concert.ConcertError._
+  import example.model.concert.ConcertEvent._
   import example.model.concert._
   import example.model.concert.actor.ConcertActor._
 
+  private val persistenceTestKit = PersistenceTestKit(system)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    persistenceTestKit.clearAll()
+  }
+
   private class EmptyConcertActorFactory(createBehavior: ConcertActorBehaviorFactory) {
-    def create(id: ConcertId): ActorRef[Command] = {
-      testKit.spawn(createBehavior(id, PersistenceId.ofUniqueId(id.value)))
+    def create(id: ConcertId, persistenceId: PersistenceId): ActorRef[Command] = {
+      testKit.spawn(createBehavior(id, persistenceId))
     }
   }
 
   private class AvailableConcertActorFactory(createBehavior: ConcertActorBehaviorFactory) {
     private val underlyingFactory = new EmptyConcertActorFactory(createBehavior)
-    def create(id: ConcertId, numOfTickets: Int): ActorRef[Command] = {
-      val actor = underlyingFactory.create(id)
+    def create(id: ConcertId, persistenceId: PersistenceId, numOfTickets: Int): ActorRef[Command] = {
+      val actor = underlyingFactory.create(id, persistenceId)
       val probe = testKit.createTestProbe[CreateResponse]()
       actor ! Create(numOfTickets, probe.ref)
       probe.expectMessageType[CreateSucceeded]
+      persistenceTestKit.expectNextPersistedType[ConcertCreated](persistenceId.id)
       actor
     }
   }
 
   private class CancelledConcertActorFactory(createBehavior: ConcertActorBehaviorFactory) {
     private val underlyingFactory = new AvailableConcertActorFactory(createBehavior)
-    def create(id: ConcertId, numOfTickets: Int): ActorRef[Command] = {
-      val actor = underlyingFactory.create(id, numOfTickets)
+    def create(id: ConcertId, persistenceId: PersistenceId, numOfTickets: Int): ActorRef[Command] = {
+      val actor = underlyingFactory.create(id, persistenceId, numOfTickets)
       val probe = testKit.createTestProbe[CancelResponse]()
       actor ! Cancel(probe.ref)
       probe.expectMessageType[CancelSucceeded]
+      persistenceTestKit.expectNextPersistedType[ConcertCancelled](persistenceId.id)
       actor
     }
   }
@@ -53,34 +65,42 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
     val factory = new EmptyConcertActorFactory(createBehavior)
 
     "can create a concert" in {
-      val id           = newConcertId()
-      val actor        = factory.create(id)
-      val numOfTickets = 3
+      val id            = newConcertId()
+      val persistenceId = PersistenceId.ofUniqueId(id.value)
+      val actor         = factory.create(id, persistenceId)
+      val numOfTickets  = 3
 
       val probe = testKit.createTestProbe[CreateResponse]()
       actor ! Create(numOfTickets, probe.ref)
       val resp = probe.expectMessageType[CreateSucceeded]
       resp.numTickets shouldBe numOfTickets
+      val createdEvent = persistenceTestKit.expectNextPersistedType[ConcertCreated](persistenceId.id)
+      createdEvent.concertId shouldBe id
+      createdEvent.numOfTickets shouldBe numOfTickets
     }
 
     "cannot get the concert if it is not created yet" in {
-      val id    = newConcertId()
-      val actor = factory.create(id)
+      val id            = newConcertId()
+      val persistenceId = PersistenceId.ofUniqueId(id.value)
+      val actor         = factory.create(id, persistenceId)
 
       val probe = testKit.createTestProbe[GetResponse]()
       actor ! Get(probe.ref)
       val resp = probe.expectMessageType[GetFailed]
       resp.error shouldBe a[ConcertNotFoundError]
+      persistenceTestKit.expectNothingPersisted(persistenceId.id)
     }
 
     "cannot cancel a concert if the concert is not created" in {
-      val id    = newConcertId()
-      val actor = factory.create(id)
+      val id            = newConcertId()
+      val persistenceId = PersistenceId.ofUniqueId(id.value)
+      val actor         = factory.create(id, persistenceId)
 
       val probe = testKit.createTestProbe[CancelResponse]()
       actor ! Cancel(probe.ref)
       val resp = probe.expectMessageType[CancelFailed]
       resp.error shouldBe a[ConcertNotFoundError]
+      persistenceTestKit.expectNothingPersisted(persistenceId.id)
     }
 
   }
@@ -90,63 +110,78 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
     val factory = new AvailableConcertActorFactory(createBehavior)
 
     "cannot create a concert if it's already exists" in {
-      val id    = newConcertId()
-      val actor = factory.create(id, numOfTickets = 3)
+      val id            = newConcertId()
+      val persistenceId = PersistenceId.ofUniqueId(id.value)
+      val actor         = factory.create(id, persistenceId, numOfTickets = 3)
 
       val probe = testKit.createTestProbe[CreateResponse]()
       actor ! Create(2, probe.ref)
       val resp = probe.expectMessageType[CreateFailed]
       resp.error shouldBe a[DuplicatedConcertError]
+      persistenceTestKit.expectNothingPersisted(persistenceId.id)
     }
 
     "can get the concert" in {
-      val id    = newConcertId()
-      val actor = factory.create(id, numOfTickets = 3)
+      val id            = newConcertId()
+      val persistenceId = PersistenceId.ofUniqueId(id.value)
+      val actor         = factory.create(id, persistenceId, numOfTickets = 3)
 
       val probe = testKit.createTestProbe[GetResponse]()
       actor ! Get(probe.ref)
       val resp = probe.expectMessageType[GetSucceeded]
       resp.tickets.size shouldBe 3
+      persistenceTestKit.expectNothingPersisted(persistenceId.id)
     }
 
     "can cancel a concert" in {
-      val id    = newConcertId()
-      val actor = factory.create(id, numOfTickets = 3)
+      val id            = newConcertId()
+      val persistenceId = PersistenceId.ofUniqueId(id.value)
+      val actor         = factory.create(id, persistenceId, numOfTickets = 3)
 
       val probe = testKit.createTestProbe[CancelResponse]()
       actor ! Cancel(probe.ref)
       val resp = probe.expectMessageType[CancelSucceeded]
       resp.numberOfTickets shouldBe 3
+      val cancelledEvent = persistenceTestKit.expectNextPersistedType[ConcertCancelled](persistenceId.id)
+      cancelledEvent.concertId shouldBe id
     }
 
     "can buy tickets" in {
-      val id    = newConcertId()
-      val actor = factory.create(id, numOfTickets = 2)
+      val id            = newConcertId()
+      val persistenceId = PersistenceId.ofUniqueId(id.value)
+      val actor         = factory.create(id, persistenceId, numOfTickets = 2)
 
       val probe = testKit.createTestProbe[BuyTicketsResponse]()
       actor ! BuyTickets(2, probe.ref)
       val resp = probe.expectMessageType[BuyTicketsSucceeded]
       resp.tickets.size shouldBe 2
+      val boughtEvent = persistenceTestKit.expectNextPersistedType[ConcertTicketsBought](persistenceId.id)
+      boughtEvent.concertId shouldBe id
+      boughtEvent.tickets shouldBe resp.tickets
     }
 
     "cannot buy no tickets" in {
-      val id    = newConcertId()
-      val actor = factory.create(id, numOfTickets = 2)
+      val id            = newConcertId()
+      val persistenceId = PersistenceId.ofUniqueId(id.value)
+      val actor         = factory.create(id, persistenceId, numOfTickets = 2)
 
       val probe = testKit.createTestProbe[BuyTicketsResponse]()
       actor ! BuyTickets(0, probe.ref)
       val resp = probe.expectMessageType[BuyTicketsFailed]
       resp.error shouldBe a[InvalidConcertOperationError]
+      persistenceTestKit.expectNothingPersisted(persistenceId.id)
     }
 
     "cannot buy exceeded tickets" in {
-      val id    = newConcertId()
-      val actor = factory.create(id, numOfTickets = 2)
+      val id            = newConcertId()
+      val persistenceId = PersistenceId.ofUniqueId(id.value)
+      val actor         = factory.create(id, persistenceId, numOfTickets = 2)
 
       val probe = testKit.createTestProbe[BuyTicketsResponse]()
       actor ! BuyTickets(3, probe.ref)
       val resp = probe.expectMessageType[BuyTicketsFailed]
       resp.error shouldBe a[InvalidConcertOperationError]
+      persistenceTestKit.expectNothingPersisted(persistenceId.id)
     }
 
   }
@@ -156,24 +191,28 @@ trait ConcertActorBehaviors extends ConcertIdGeneratorSupport {
     val factory = new CancelledConcertActorFactory(createBehavior)
 
     "can get the concert even if it is cancelled" in {
-      val id    = newConcertId()
-      val actor = factory.create(id, numOfTickets = 2)
+      val id            = newConcertId()
+      val persistenceId = PersistenceId.ofUniqueId(id.value)
+      val actor         = factory.create(id, persistenceId, numOfTickets = 2)
 
       val probe = testKit.createTestProbe[GetResponse]()
       actor ! Get(probe.ref)
       val resp = probe.expectMessageType[GetSucceeded]
       resp.tickets.size shouldBe 2
       resp.cancelled shouldBe true
+      persistenceTestKit.expectNothingPersisted(persistenceId.id)
     }
 
     "cannot cancel a concert if the concert is already cancelled" in {
-      val id    = newConcertId()
-      val actor = factory.create(id, numOfTickets = 1)
+      val id            = newConcertId()
+      val persistenceId = PersistenceId.ofUniqueId(id.value)
+      val actor         = factory.create(id, persistenceId, numOfTickets = 1)
 
       val probe = testKit.createTestProbe[CancelResponse]()
       actor ! Cancel(probe.ref)
       val resp = probe.expectMessageType[CancelFailed]
       resp.error shouldBe a[InvalidConcertOperationError]
+      persistenceTestKit.expectNothingPersisted(persistenceId.id)
     }
 
   }

--- a/sample-app/src/test/scala/example/model/concert/actor/ConcertActorSpecBase.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/ConcertActorSpecBase.scala
@@ -1,12 +1,13 @@
 package example.model.concert.actor
 
-import akka.persistence.testkit.PersistenceTestKitPlugin
+import akka.persistence.testkit.{ PersistenceTestKitPlugin, PersistenceTestKitSnapshotPlugin }
 import com.typesafe.config.{ Config, ConfigFactory }
 import example.ActorSpecBase
 
 object ConcertActorSpecBase {
   private val config: Config = {
     PersistenceTestKitPlugin.config
+      .withFallback(PersistenceTestKitSnapshotPlugin.config)
       .withFallback(ConfigFactory.load)
   }
 }

--- a/sample-app/src/test/scala/example/model/concert/actor/ConcertActorSpecBase.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/ConcertActorSpecBase.scala
@@ -1,0 +1,17 @@
+package example.model.concert.actor
+
+import akka.persistence.testkit.PersistenceTestKitPlugin
+import com.typesafe.config.{ Config, ConfigFactory }
+import example.ActorSpecBase
+
+object ConcertActorSpecBase {
+  private val config: Config = {
+    PersistenceTestKitPlugin.config
+      .withFallback(ConfigFactory.load)
+  }
+}
+
+abstract class ConcertActorSpecBase
+    extends ActorSpecBase(ConcertActorSpecBase.config)
+    with ConcertActorBehaviors
+    with ConcertActorClusterShardingBehaviors

--- a/sample-app/src/test/scala/example/model/concert/actor/DefaultConcertActorSpec.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/DefaultConcertActorSpec.scala
@@ -1,11 +1,6 @@
 package example.model.concert.actor
 
-import example.ActorSpecBase
-
-final class DefaultConcertActorSpec
-    extends ActorSpecBase()
-    with ConcertActorBehaviors
-    with ConcertActorClusterShardingBehaviors {
+final class DefaultConcertActorSpec extends ConcertActorSpecBase {
 
   private def createBehavior: ConcertActorBehaviorFactory = DefaultConcertActor
 

--- a/sample-app/src/test/scala/example/model/concert/actor/DefaultConcertActorSpec.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/DefaultConcertActorSpec.scala
@@ -9,6 +9,7 @@ final class DefaultConcertActorSpec extends ConcertActorSpecBase {
     behave like availableConcertActor(createBehavior)
     behave like cancelledConcertActor(createBehavior)
     behave like shardedActor(createBehavior)
+    behave like snapshotPersistenceActor(createBehavior)
   }
 
 }

--- a/sample-app/src/test/scala/example/model/concert/actor/DefaultConcertActorWithEventPersistenceSpec.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/DefaultConcertActorWithEventPersistenceSpec.scala
@@ -1,11 +1,6 @@
 package example.model.concert.actor
 
-import example.ActorSpecBase
-
-final class DefaultConcertActorWithEventPersistenceSpec
-    extends ActorSpecBase()
-    with ConcertActorBehaviors
-    with ConcertActorClusterShardingBehaviors {
+final class DefaultConcertActorWithEventPersistenceSpec extends ConcertActorSpecBase {
 
   private def createBehavior: ConcertActorBehaviorFactory = DefaultConcertActorWithEventPersistence
 

--- a/sample-app/src/test/scala/example/model/concert/actor/MyConcertActorSpec.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/MyConcertActorSpec.scala
@@ -1,13 +1,9 @@
 package example.model.concert.actor
 
-import example.ActorSpecBase
 import example.testing.tags.ExerciseTest
 
 @ExerciseTest
-final class MyConcertActorSpec
-    extends ActorSpecBase()
-    with ConcertActorBehaviors
-    with ConcertActorClusterShardingBehaviors {
+final class MyConcertActorSpec extends ConcertActorSpecBase {
 
   private def createBehavior: ConcertActorBehaviorFactory = MyConcertActor
 

--- a/sample-app/src/test/scala/example/model/concert/actor/MyConcertActorSpec.scala
+++ b/sample-app/src/test/scala/example/model/concert/actor/MyConcertActorSpec.scala
@@ -12,6 +12,8 @@ final class MyConcertActorSpec extends ConcertActorSpecBase {
     behave like availableConcertActor(createBehavior)
     behave like cancelledConcertActor(createBehavior)
     behave like shardedActor(createBehavior)
+    // スナップショットの実装時にコメントアウトを外す (この行はそのまま)
+    // behave like snapshotPersistenceActor(createBehavior)
   }
 
 }


### PR DESCRIPTION
ConcertActor の イベント永続化、スナップショット永続化テストを追加します。
Akka Typed になったことで、テストキットを使用した永続化のテストが容易になりました。

Persistence の TestKit は、次の公式ドキュメントが提供されています。
[Testing • Akka Documentation](https://doc.akka.io/docs/akka/current/typed/persistence-testing.html#persistence-testkit)

テストキットには2種類あります。
2つ目の `PersistenceTestKit`, `SnapshotTestKit` を使用します。
スナップショットまでテストでき、Actorのテストと容易に組み合わせられるためです。
- `EventSourcedBehaviorTestKit`
- `PersistenceTestKit` & `SnapshotTestKit`