### PR TITLE
テスト時のログ出力を静かにする

### DIFF
--- a/sample-app/src/test/resources/logback-test.xml
+++ b/sample-app/src/test/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%-4level] [%d{MM/dd/yyyy HH:mm:ss.SSS}] [%thread] [%logger{36}] %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+    <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <root level="DEBUG">
+        <appender-ref ref="CapturingAppender"/>
+    </root>
+
+</configuration>

--- a/sample-app/src/test/scala/example/ActorSpecBase.scala
+++ b/sample-app/src/test/scala/example/ActorSpecBase.scala
@@ -1,6 +1,6 @@
 package example
 
-import akka.actor.testkit.typed.scaladsl.{ ActorTestKit, ScalaTestWithActorTestKit }
+import akka.actor.testkit.typed.scaladsl.{ ActorTestKit, LogCapturing, ScalaTestWithActorTestKit }
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import org.scalatest.matchers.should.Matchers
@@ -21,7 +21,8 @@ abstract class ActorSpecBase(testKit: ActorTestKit)
     with Eventually
     with ScalaFutures
     with EitherValues
-    with AkkaTypedSpanScaleFactorSupport {
+    with AkkaTypedSpanScaleFactorSupport
+    with LogCapturing {
 
   def this() = {
     // デフォルトの振る舞いでは `application-test` もしくは `reference` のみが読み込まれる。

--- a/sample-app/src/test/scala/example/RouteSpecBase.scala
+++ b/sample-app/src/test/scala/example/RouteSpecBase.scala
@@ -1,5 +1,6 @@
 package example
 
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.mockito.IdiomaticMockito
@@ -24,3 +25,4 @@ abstract class RouteSpecBase
     with SprayJsonSupport
     with IdiomaticMockito
     with AkkaSpanScaleFactorSupport
+    with LogCapturing

--- a/sample-app/src/test/scala/example/SpecBase.scala
+++ b/sample-app/src/test/scala/example/SpecBase.scala
@@ -1,5 +1,6 @@
 package example
 
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.{ EitherValues, Inside }
@@ -8,4 +9,4 @@ import org.scalatest.{ EitherValues, Inside }
   *
   * @see [[https://www.scalatest.org/user_guide/defining_base_classes Defining base classes for your project]]
   */
-abstract class SpecBase extends AnyWordSpecLike with Matchers with Inside with EitherValues
+abstract class SpecBase extends AnyWordSpecLike with Matchers with Inside with EitherValues with LogCapturing


### PR DESCRIPTION
ハンズオン準備等で `sbt testAll` を実行します。
テストにパスしたのかどうかを分かりやすくするため、
テストが成功している場合はログ出力を標準出力に表示しないようにします。
テストが失敗した場合には、その失敗したテストのログが標準出力に表示されます。

次のドキュメントから設定方法を確認できます。
[Silence logging output from tests | Asynchronous testing • Akka Documentation](https://doc.akka.io/docs/akka/current/typed/testing-async.html#silence-logging-output-from-tests)

次の PR にて、テストが失敗した場合に、失敗したテストケースのログだけが標準出力に表示されることが確認できます。
[[DONT MERGE] 失敗したテストはログが出力されることを確認する by xirc · Pull Request #40 · lerna-stack/lerna-handson](https://github.com/lerna-stack/lerna-handson/pull/40)

過去のテストにてどのようにログ出力が標準出力に表示されていたのかの1例は、
[Merge branch 'feature/develop' into mariadb-ops-doc · lerna-stack/lerna-handson@0f4fb06](https://github.com/lerna-stack/lerna-handson/runs/2606852189) から確認できます。