### PR TITLE
[DONT MERGE] 失敗したテストはログが出力されることを確認する

### DIFF
--- a/sample-app/src/test/scala/example/application/command/actor/ConcertActorBehaviors.scala
+++ b/sample-app/src/test/scala/example/application/command/actor/ConcertActorBehaviors.scala
@@ -78,7 +78,7 @@ trait ConcertActorBehaviors extends BeforeAndAfterEach with ConcertIdGeneratorSu
       resp.numTickets shouldBe numOfTickets
       val createdEvent = persistenceTestKit.expectNextPersistedType[ConcertCreated](persistenceId.id)
       createdEvent.concertId shouldBe id
-      createdEvent.numOfTickets shouldBe numOfTickets
+      createdEvent.numOfTickets shouldBe 2
     }
 
     "cannot get the concert if it is not created yet" in {
@@ -131,7 +131,7 @@ trait ConcertActorBehaviors extends BeforeAndAfterEach with ConcertIdGeneratorSu
       val probe = testKit.createTestProbe[GetResponse]()
       actor ! Get(probe.ref)
       val resp = probe.expectMessageType[GetSucceeded]
-      resp.tickets.size shouldBe 3
+      resp.tickets.size shouldBe 2
       persistenceTestKit.expectNothingPersisted(persistenceId.id)
     }
 


### PR DESCRIPTION
[テスト時のログ出力を静かにする by xirc · Pull Request #39 · lerna-stack/lerna-handson](https://github.com/lerna-stack/lerna-handson/pull/39)
で、テスト成功時にはログが出力されなくなります。
このPRでは、テスト失敗時には失敗したテストケースのみログが出力されることを確認できます。

※このPRは、上記PRのマージが済み次第、マージせずにクローズします。