### PR TITLE
Update sbt to 1.5.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ target/
 # sbt
 sbt-cache/
 
+# BSP
+.bsp/
+
 # lightbend credentials
 .lightbend/commercial.credentials
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ lerna-handson に関する注目すべき変更はこのファイルで文書化
 このファイルの書き方については [Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) を参照してください。
 
 ## Unreleased
-
+- sbt 1.5.5 に更新します [PR#43](https://github.com/lerna-stack/lerna-handson/pull/43)
 
 ## v1.1.0
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.13
+sbt.version = 1.5.5

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,2 +1,0 @@
-// NOTE: project/*** で使う scala version
-scalaVersion := "2.12.8"

--- a/scripts/runServer1.sh
+++ b/scripts/runServer1.sh
@@ -2,6 +2,7 @@
 
 # クラスタノード 1台目
 sbt \
+-Dsbt.server.forcestart=true \
 -DHOST=127.0.0.1 \
 -DPORT=25521 \
 -DAPP_HOST=127.0.0.1 \

--- a/scripts/runServer2.sh
+++ b/scripts/runServer2.sh
@@ -2,6 +2,7 @@
 
 # クラスタノード 2台目
 sbt \
+-Dsbt.server.forcestart=true \
 -DHOST=127.0.0.1 \
 -DPORT=25522 \
 -DAPP_HOST=127.0.0.1 \

--- a/scripts/runServer3.sh
+++ b/scripts/runServer3.sh
@@ -2,6 +2,7 @@
 
 # クラスタノード 3台目
 sbt \
+-Dsbt.server.forcestart=true \
 -DHOST=127.0.0.1 \
 -DPORT=25523 \
 -DAPP_HOST=127.0.0.1 \


### PR DESCRIPTION
sbt 1.5.5 に更新します。

1.3.13 から 1.5.5 までリリースは次の URL から確認できます。
- https://github.com/sbt/sbt/releases/tag/v1.4.0
- https://github.com/sbt/sbt/releases/tag/v1.4.1
- https://github.com/sbt/sbt/releases/tag/v1.4.2
- https://github.com/sbt/sbt/releases/tag/v1.4.4
- https://github.com/sbt/sbt/releases/tag/v1.4.5
- https://github.com/sbt/sbt/releases/tag/v1.4.6
- https://github.com/sbt/sbt/releases/tag/v1.4.7
- https://github.com/sbt/sbt/releases/tag/v1.4.8
- https://github.com/sbt/sbt/releases/tag/v1.4.9
- https://github.com/sbt/sbt/releases/tag/v1.5.0
- https://github.com/sbt/sbt/releases/tag/v1.5.1
- https://github.com/sbt/sbt/releases/tag/v1.5.2
- https://github.com/sbt/sbt/releases/tag/v1.5.3
- https://github.com/sbt/sbt/releases/tag/v1.5.4
- https://github.com/sbt/sbt/releases/tag/v1.5.5