### PR TITLE
Update Scala to 2.13.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ lerna-handson に関する注目すべき変更はこのファイルで文書化
 
 ## Unreleased
 - sbt 1.5.5 に更新します [PR#43](https://github.com/lerna-stack/lerna-handson/pull/43)
+- Scala 2.13.7 に更新します [PR#44](https://github.com/lerna-stack/lerna-handson/pull/44)
 
 ## v1.1.0
 

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ ThisBuild / homepage := Some(url("https://github.com/lerna-stack/lerna-handson")
 
 // このビルドで使う scala version
 // サブプロジェクトで上書きしない限り適用される。
-ThisBuild / scalaVersion := "2.13.3"
+ThisBuild / scalaVersion := "2.13.7"
 ThisBuild / scalacOptions ++= Seq(
   "-encoding",
   "utf8",


### PR DESCRIPTION
Scala 2.13.7 に更新します。

リリースは次の URL から確認できます。
- https://github.com/scala/scala/releases/tag/v2.13.4
- https://github.com/scala/scala/releases/tag/v2.13.5
- https://github.com/scala/scala/releases/tag/v2.13.6
- https://github.com/scala/scala/releases/tag/v2.13.7

## TODO
* [x] CHANGELOG を更新する