### PR TITLE
Update Akka to 2.6.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ lerna-handson に関する注目すべき変更はこのファイルで文書化
 ## Unreleased
 - sbt 1.5.5 に更新します [PR#43](https://github.com/lerna-stack/lerna-handson/pull/43)
 - Scala 2.13.7 に更新します [PR#44](https://github.com/lerna-stack/lerna-handson/pull/44)
+- Akka 2.6.17 に更新します [PR#45](https://github.com/lerna-stack/lerna-handson/pull/45)
 
 ## v1.1.0
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val akka                     = "2.6.14"
+    val akka                     = "2.6.17"
     val akkaHttp                 = "10.2.4"
     val akkaProjection           = "1.1.0"
     val scalaTest                = "3.2.2"


### PR DESCRIPTION
Akka 2.6.17 に更新します。

リリースは次の URL から確認できます。
- https://github.com/akka/akka/releases/tag/v2.6.15
- https://github.com/akka/akka/releases/tag/v2.6.16
- https://github.com/akka/akka/releases/tag/v2.6.17

## TODO
- [x] CHANGELOG を更新する
- [x] README にある5つの curl コマンド例 で動作確認する