### PR TITLE
Update akka-http to 10.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ lerna-handson に関する注目すべき変更はこのファイルで文書化
 - sbt 1.5.5 に更新します [PR#43](https://github.com/lerna-stack/lerna-handson/pull/43)
 - Scala 2.13.7 に更新します [PR#44](https://github.com/lerna-stack/lerna-handson/pull/44)
 - Akka 2.6.17 に更新します [PR#45](https://github.com/lerna-stack/lerna-handson/pull/45)
+- Akka HTTP 10.2.7 に更新します [PR#46](https://github.com/lerna-stack/lerna-handson/pull/46)
 
 ## v1.1.0
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   object Versions {
     val akka                     = "2.6.17"
-    val akkaHttp                 = "10.2.4"
+    val akkaHttp                 = "10.2.7"
     val akkaProjection           = "1.1.0"
     val scalaTest                = "3.2.2"
     val mockitoScala             = "1.15.0"


### PR DESCRIPTION
Akka HTTP 10.2.7 に更新します。

リリースは次の URL から確認できます。
- https://doc.akka.io/docs/akka-http/current/release-notes/10.2.x.html
- https://github.com/akka/akka-http/releases/tag/v10.2.5
- https://github.com/akka/akka-http/releases/tag/v10.2.6
- https://github.com/akka/akka-http/releases/tag/v10.2.7

## TODO
- [x] CHANGELOG を更新する
- [x] README にある5つの curl コマンド例 で動作確認する