### PR TITLE
Update slick to 3.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ lerna-handson に関する注目すべき変更はこのファイルで文書化
 - Scala 2.13.7 に更新します [PR#44](https://github.com/lerna-stack/lerna-handson/pull/44)
 - Akka 2.6.17 に更新します [PR#45](https://github.com/lerna-stack/lerna-handson/pull/45)
 - Akka HTTP 10.2.7 に更新します [PR#46](https://github.com/lerna-stack/lerna-handson/pull/46)
+- Slick 3.3.3 に更新します [PR#47](https://github.com/lerna-stack/lerna-handson/pull/47)
 - sbt Native Packager への依存を削除します [PR#50](https://github.com/lerna-stack/lerna-handson/pull/50)
 
 ## v1.1.0

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val kryo                     = "1.1.5"
     val airframe                 = "20.9.0"
     val accord                   = "0.7.6"
-    val slick                    = "3.3.2"
+    val slick                    = "3.3.3"
     val h2                       = "1.4.200"
     val mariadbConnectorJ        = "2.6.2"
     val logback                  = "1.2.3"


### PR DESCRIPTION
Slick 3.3.3 に更新します。

リリースは次の URL から確認できます。
https://github.com/slick/slick/releases/tag/v3.3.3

## TODO
- [x] CHANGELOG を更新する
- [x] README にある5つの curl コマンド例 で動作確認する