### PR TITLE
Update scalatest to 3.2.10

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
     val akka                     = "2.6.14"
     val akkaHttp                 = "10.2.4"
     val akkaProjection           = "1.1.0"
-    val scalaTest                = "3.2.2"
+    val scalaTest                = "3.2.10"
     val mockitoScala             = "1.15.0"
     val akkaPersistenceCassandra = "1.0.1"
     val kryo                     = "1.1.5"


### PR DESCRIPTION
ScalaTest 3.2.10 に更新します。

リリースは次の URL から確認できます。
- https://www.scalatest.org/release_notes/3.2.3
- https://www.scalatest.org/release_notes/3.2.4
- https://www.scalatest.org/release_notes/3.2.5
- https://www.scalatest.org/release_notes/3.2.6
- https://www.scalatest.org/release_notes/3.2.7
- https://www.scalatest.org/release_notes/3.2.8
- https://www.scalatest.org/release_notes/3.2.9
- https://www.scalatest.org/release_notes/3.2.10

## TODO
- [ ] CHANGELOG を確認する
- [ ] README にある5つの curl コマンド例 で動作確認する