### PR TITLE
Update akka-persistence-cassandra to 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ lerna-handson に関する注目すべき変更はこのファイルで文書化
 - Akka 2.6.17 に更新します [PR#45](https://github.com/lerna-stack/lerna-handson/pull/45)
 - Akka HTTP 10.2.7 に更新します [PR#46](https://github.com/lerna-stack/lerna-handson/pull/46)
 - Slick 3.3.3 に更新します [PR#47](https://github.com/lerna-stack/lerna-handson/pull/47)
+- Akka Persistence Cassandra 1.0.5 に更新します [PR#49](https://github.com/lerna-stack/lerna-handson/pull/49)
 - sbt Native Packager への依存を削除します [PR#50](https://github.com/lerna-stack/lerna-handson/pull/50)
 
 ## v1.1.0

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val akkaProjection           = "1.1.0"
     val scalaTest                = "3.2.2"
     val mockitoScala             = "1.15.0"
-    val akkaPersistenceCassandra = "1.0.1"
+    val akkaPersistenceCassandra = "1.0.5"
     val kryo                     = "1.1.5"
     val airframe                 = "20.9.0"
     val accord                   = "0.7.6"


### PR DESCRIPTION
Akka Persistence Cassandra 1.0.5 に更新します。

リリースは次の URL から確認できます。
- https://github.com/akka/akka-persistence-cassandra/releases/tag/v1.0.2
- https://github.com/akka/akka-persistence-cassandra/releases/tag/v1.0.3
- https://github.com/akka/akka-persistence-cassandra/releases/tag/v1.0.4
- https://github.com/akka/akka-persistence-cassandra/releases/tag/v1.0.5

## TODO
- [x] CHANGELOG を更新する
- [x] README にある5つの curl コマンド例 で動作確認する